### PR TITLE
Ajustes nas telas de Cadastros

### DIFF
--- a/App/view/cadastroPessoas.py
+++ b/App/view/cadastroPessoas.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import QWidget, QLineEdit, QComboBox, QDateEdit
 from PyQt5.uic import loadUi
-from PyQt5.QtCore import pyqtSlot
+from PyQt5.QtCore import pyqtSlot, QDate
 from App.controller.pessoa import cadastrarPessoa
 from App.controller.utils import modificarData
 from App.controller.utils import validarAcao
@@ -10,6 +10,12 @@ class cadastroPessoas(QWidget):
     def __init__(self):
         super().__init__()
         loadUi('App/view/ui/cadastroPessoas.ui',self)
+
+        self.dataDeNascimento = self.findChild(QDateEdit, 'dataDeNascimento')
+
+        self.dataDeNascimento.setCalendarPopup(True)
+        self.dataDeNascimento.setDisplayFormat('dd/MM/yyyy')
+        self.dataDeNascimento.setDate(QDate.currentDate()) 
     
     def getDadosCadastro(self):
         nomePessoas = self.nomePessoas.text().strip()

--- a/App/view/ui/cadastroArea.ui
+++ b/App/view/ui/cadastroArea.ui
@@ -26,11 +26,11 @@ border-radius: 15px;
 }
 
 #cadastrarArea {
-background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
 	border-bottom-color:rgba(46,82,101,200);
-	color:rgb(0,0,0);
-	padding-bottom:7px;
+	border: none;
+	border-radius: 12px
 }
 
 #resposta {

--- a/App/view/ui/cadastroCurso.ui
+++ b/App/view/ui/cadastroCurso.ui
@@ -15,11 +15,11 @@
   </property>
   <property name="styleSheet">
    <string notr="true">QLineEdit, QComboBox {
-	background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
-	padding-bottom:7px;
+	border-radius: 5px;
 }
 
 #btnCadastrarCurso {

--- a/App/view/ui/cadastroCurso.ui
+++ b/App/view/ui/cadastroCurso.ui
@@ -288,10 +288,10 @@ border-radius: 15px;
        <cursorShape>PointingHandCursor</cursorShape>
       </property>
       <property name="editable">
-       <bool>true</bool>
+       <bool>false</bool>
       </property>
       <property name="currentText">
-       <string>Área</string>
+       <string/>
       </property>
      </widget>
      <widget class="QLabel" name="label_2">

--- a/App/view/ui/cadastroCurso.ui
+++ b/App/view/ui/cadastroCurso.ui
@@ -100,7 +100,7 @@ border-radius: 15px;
       <property name="geometry">
        <rect>
         <x>70</x>
-        <y>213</y>
+        <y>200</y>
         <width>131</width>
         <height>20</height>
        </rect>
@@ -144,16 +144,16 @@ border-radius: 15px;
       <property name="geometry">
        <rect>
         <x>70</x>
-        <y>250</y>
+        <y>231</y>
         <width>111</width>
-        <height>22</height>
+        <height>41</height>
        </rect>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
       </property>
       <property name="editable">
-       <bool>true</bool>
+       <bool>false</bool>
       </property>
       <item>
        <property name="text">
@@ -274,9 +274,9 @@ border-radius: 15px;
       <property name="geometry">
        <rect>
         <x>530</x>
-        <y>80</y>
+        <y>90</y>
         <width>231</width>
-        <height>51</height>
+        <height>41</height>
        </rect>
       </property>
       <property name="font">

--- a/App/view/ui/cadastroLogin.ui
+++ b/App/view/ui/cadastroLogin.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>784</width>
+    <width>786</width>
     <height>656</height>
    </rect>
   </property>
@@ -15,8 +15,9 @@
   </property>
   <property name="styleSheet">
    <string notr="true">QLineEdit, QComboBox {
-	background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
+	border-radius: 6px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;
@@ -25,8 +26,8 @@
 #btnCdastrarLogin {
 	background-color: #01498a;
 	color: #FFF;
-border: none;
-border-radius: 15px;
+	border: none;
+	border-radius: 15px;
 }
 
 #btnCdastrarLogin:hover {

--- a/App/view/ui/cadastroPessoas.ui
+++ b/App/view/ui/cadastroPessoas.ui
@@ -15,18 +15,19 @@
   </property>
   <property name="styleSheet">
    <string notr="true">QLineEdit, QComboBox, QDateEdit {
-	background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
+	border-radius: 6px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
-	padding-bottom:7px;
+	padding-bottom:5px;
 }
 
 #btnCadastrar {
 	background-color: #01498a;
 	color: #FFF;
 	border: none;
-	border-radius: 5px;
+	border-radius: 6px;
 }
 
 #btnCadastrar:hover {

--- a/App/view/ui/cadastroPessoas.ui
+++ b/App/view/ui/cadastroPessoas.ui
@@ -17,7 +17,7 @@
    <string notr="true">QLineEdit, QComboBox, QDateEdit {
 	background-color: white;
 	border:2px solid rgba(0,0,0,0);
-	border-radius: 3px;
+	border-radius: 2px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:5px;
@@ -147,9 +147,9 @@
     <property name="geometry">
      <rect>
       <x>440</x>
-      <y>50</y>
+      <y>41</y>
       <width>151</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
    </widget>
@@ -173,9 +173,9 @@
     <property name="geometry">
      <rect>
       <x>490</x>
-      <y>120</y>
+      <y>111</y>
       <width>110</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">
@@ -186,9 +186,9 @@
     <property name="geometry">
      <rect>
       <x>410</x>
-      <y>180</y>
+      <y>171</y>
       <width>113</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="text">
@@ -199,16 +199,16 @@
     <property name="geometry">
      <rect>
       <x>100</x>
-      <y>180</y>
+      <y>171</y>
       <width>101</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">
      <cursorShape>PointingHandCursor</cursorShape>
     </property>
     <property name="editable">
-     <bool>true</bool>
+     <bool>false</bool>
     </property>
     <item>
      <property name="text">

--- a/App/view/ui/cadastroPessoas.ui
+++ b/App/view/ui/cadastroPessoas.ui
@@ -17,7 +17,7 @@
    <string notr="true">QLineEdit, QComboBox, QDateEdit {
 	background-color: white;
 	border:2px solid rgba(0,0,0,0);
-	border-radius: 6px;
+	border-radius: 3px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:5px;

--- a/App/view/ui/cadastroSalas.ui
+++ b/App/view/ui/cadastroSalas.ui
@@ -15,8 +15,9 @@
   </property>
   <property name="styleSheet">
    <string notr="true">QLineEdit, QComboBox {
-	background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
+	border-radius: 2px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;
@@ -82,6 +83,9 @@
       <height>101</height>
      </rect>
     </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
     <property name="placeholderText">
      <string>Observações adicionais</string>
     </property>
@@ -126,6 +130,9 @@
       <width>133</width>
       <height>31</height>
      </rect>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
     </property>
     <property name="placeholderText">
      <string>Capacidade Média</string>

--- a/App/view/ui/cadastroSalas.ui
+++ b/App/view/ui/cadastroSalas.ui
@@ -17,10 +17,10 @@
    <string notr="true">QLineEdit, QComboBox {
 	background-color: white;
 	border:2px solid rgba(0,0,0,0);
-	border-radius: 2px;
+	border-radius: 3px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
-	padding-bottom:7px;
+	padding-bottom:3px;
 }
 
 #cadastrarSala {
@@ -168,16 +168,16 @@
     <property name="geometry">
      <rect>
       <x>99</x>
-      <y>79</y>
+      <y>69</y>
       <width>81</width>
-      <height>21</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">
      <cursorShape>PointingHandCursor</cursorShape>
     </property>
     <property name="editable">
-     <bool>true</bool>
+     <bool>false</bool>
     </property>
     <property name="currentText">
      <string notr="true">Prédio 1</string>
@@ -213,16 +213,16 @@
     <property name="geometry">
      <rect>
       <x>400</x>
-      <y>19</y>
+      <y>9</y>
       <width>81</width>
-      <height>21</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">
      <cursorShape>PointingHandCursor</cursorShape>
     </property>
     <property name="editable">
-     <bool>true</bool>
+     <bool>false</bool>
     </property>
     <property name="currentText">
      <string>Comum</string>

--- a/App/view/ui/editarArea.ui
+++ b/App/view/ui/editarArea.ui
@@ -15,8 +15,9 @@
   </property>
   <property name="styleSheet">
    <string notr="true">QLineEdit, QComboBox {
-	background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
+	border-radius: 12px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;

--- a/App/view/ui/editarCurso.ui
+++ b/App/view/ui/editarCurso.ui
@@ -15,8 +15,9 @@
   </property>
   <property name="styleSheet">
    <string notr="true">QLineEdit, QComboBox {
-	background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
+	border-radius: 5px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;
@@ -25,8 +26,8 @@
 #btnEditarCurso {
 	background-color: #01498a;
 	color: #FFF;
-border: none;
-border-radius: 15px;
+	border: none;
+	border-radius: 15px;
 }
  
 #btnEditarCurso:hover {

--- a/App/view/ui/editarCurso.ui
+++ b/App/view/ui/editarCurso.ui
@@ -17,7 +17,7 @@
    <string notr="true">QLineEdit, QComboBox {
 	background-color: white;
 	border:2px solid rgba(0,0,0,0);
-	border-radius: 5px;
+	border-radius: 4px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;
@@ -248,16 +248,16 @@
     <property name="geometry">
      <rect>
       <x>70</x>
-      <y>250</y>
+      <y>241</y>
       <width>81</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">
      <cursorShape>PointingHandCursor</cursorShape>
     </property>
     <property name="editable">
-     <bool>true</bool>
+     <bool>false</bool>
     </property>
     <item>
      <property name="text">
@@ -279,16 +279,16 @@
     <property name="geometry">
      <rect>
       <x>580</x>
-      <y>140</y>
+      <y>130</y>
       <width>69</width>
-      <height>21</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">
      <cursorShape>PointingHandCursor</cursorShape>
     </property>
     <property name="editable">
-     <bool>true</bool>
+     <bool>false</bool>
     </property>
    </widget>
    <widget class="QLabel" name="label_8">
@@ -308,9 +308,9 @@
     <property name="geometry">
      <rect>
       <x>580</x>
-      <y>250</y>
+      <y>241</y>
       <width>69</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">

--- a/App/view/ui/editarLogin.ui
+++ b/App/view/ui/editarLogin.ui
@@ -15,8 +15,9 @@
   </property>
   <property name="styleSheet">
    <string notr="true">QLineEdit, QComboBox {
-	background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
+	border-radius: 13px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;
@@ -25,8 +26,8 @@
 #btnEditarLogin {
 	background-color: #01498a;
 	color: #FFF;
-border: none;
-border-radius: 15px;
+	border: none;
+	border-radius: 15px;
 }
  
 #btnEditarLogin:hover {

--- a/App/view/ui/editarLogin.ui
+++ b/App/view/ui/editarLogin.ui
@@ -17,7 +17,7 @@
    <string notr="true">QLineEdit, QComboBox {
 	background-color: white;
 	border:2px solid rgba(0,0,0,0);
-	border-radius: 13px;
+	border-radius: 4px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;
@@ -57,9 +57,9 @@
     <property name="geometry">
      <rect>
       <x>20</x>
-      <y>120</y>
+      <y>109</y>
       <width>113</width>
-      <height>20</height>
+      <height>31</height>
      </rect>
     </property>
    </widget>
@@ -67,9 +67,9 @@
     <property name="geometry">
      <rect>
       <x>270</x>
-      <y>120</y>
+      <y>109</y>
       <width>113</width>
-      <height>20</height>
+      <height>31</height>
      </rect>
     </property>
    </widget>
@@ -77,16 +77,16 @@
     <property name="geometry">
      <rect>
       <x>30</x>
-      <y>250</y>
+      <y>241</y>
       <width>69</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">
      <cursorShape>PointingHandCursor</cursorShape>
     </property>
     <property name="editable">
-     <bool>true</bool>
+     <bool>false</bool>
     </property>
    </widget>
    <widget class="QLabel" name="label">
@@ -145,9 +145,9 @@
     <property name="geometry">
      <rect>
       <x>500</x>
-      <y>120</y>
+      <y>110</y>
       <width>71</width>
-      <height>21</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">

--- a/App/view/ui/editarPessoa.ui
+++ b/App/view/ui/editarPessoa.ui
@@ -15,8 +15,9 @@
   </property>
   <property name="styleSheet">
    <string notr="true">QLineEdit, QComboBox, QDateEdit {
-	background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
+	border-radius: 15px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;

--- a/App/view/ui/editarPessoa.ui
+++ b/App/view/ui/editarPessoa.ui
@@ -17,7 +17,7 @@
    <string notr="true">QLineEdit, QComboBox, QDateEdit {
 	background-color: white;
 	border:2px solid rgba(0,0,0,0);
-	border-radius: 15px;
+	border-radius: 3px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;
@@ -148,9 +148,9 @@ border-radius: 15px;
     <property name="geometry">
      <rect>
       <x>70</x>
-      <y>80</y>
+      <y>71</y>
       <width>251</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="text">
@@ -161,9 +161,9 @@ border-radius: 15px;
     <property name="geometry">
      <rect>
       <x>430</x>
-      <y>80</y>
+      <y>71</y>
       <width>151</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
    </widget>
@@ -171,9 +171,9 @@ border-radius: 15px;
     <property name="geometry">
      <rect>
       <x>70</x>
-      <y>150</y>
+      <y>141</y>
       <width>251</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
    </widget>
@@ -181,9 +181,9 @@ border-radius: 15px;
     <property name="geometry">
      <rect>
       <x>490</x>
-      <y>147</y>
+      <y>138</y>
       <width>110</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">
@@ -194,9 +194,9 @@ border-radius: 15px;
     <property name="geometry">
      <rect>
       <x>310</x>
-      <y>210</y>
+      <y>205</y>
       <width>113</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
    </widget>
@@ -204,9 +204,9 @@ border-radius: 15px;
     <property name="geometry">
      <rect>
       <x>70</x>
-      <y>215</y>
+      <y>206</y>
       <width>101</width>
-      <height>22</height>
+      <height>31</height>
      </rect>
     </property>
     <property name="cursor">
@@ -235,32 +235,6 @@ border-radius: 15px;
       <string>Administrador</string>
      </property>
     </item>
-   </widget>
-   <widget class="QComboBox" name="alterarPessoas">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>320</y>
-      <width>69</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="cursor">
-     <cursorShape>PointingHandCursor</cursorShape>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_8">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>290</y>
-      <width>91</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Alterar Cadastro:</string>
-    </property>
    </widget>
   </widget>
   <widget class="QPushButton" name="btnEditar">
@@ -300,7 +274,6 @@ border-radius: 15px;
   <tabstop>dataDeNascimento</tabstop>
   <tabstop>cargo</tabstop>
   <tabstop>telefone</tabstop>
-  <tabstop>alterarPessoas</tabstop>
   <tabstop>btnEditar</tabstop>
  </tabstops>
  <resources/>

--- a/App/view/ui/editarReserva.ui
+++ b/App/view/ui/editarReserva.ui
@@ -15,8 +15,9 @@
   </property>
   <property name="styleSheet">
    <string notr="true">QLineEdit, QComboBox, QTimeEdit, QDateEdit {
-	background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
+	border-radius: 5px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;

--- a/App/view/ui/editarReserva.ui
+++ b/App/view/ui/editarReserva.ui
@@ -17,7 +17,7 @@
    <string notr="true">QLineEdit, QComboBox, QTimeEdit, QDateEdit {
 	background-color: white;
 	border:2px solid rgba(0,0,0,0);
-	border-radius: 5px;
+	border-radius: 3px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;
@@ -194,7 +194,7 @@ border-radius: 15px;
         <x>20</x>
         <y>150</y>
         <width>161</width>
-        <height>20</height>
+        <height>31</height>
        </rect>
       </property>
      </widget>
@@ -230,7 +230,7 @@ border-radius: 15px;
         <x>320</x>
         <y>80</y>
         <width>111</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="editable">
@@ -243,7 +243,7 @@ border-radius: 15px;
         <x>320</x>
         <y>147</y>
         <width>111</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="editable">
@@ -256,7 +256,7 @@ border-radius: 15px;
         <x>20</x>
         <y>80</y>
         <width>161</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="editable">
@@ -289,11 +289,11 @@ border-radius: 15px;
         <x>560</x>
         <y>147</y>
         <width>111</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="editable">
-       <bool>true</bool>
+       <bool>false</bool>
       </property>
       <item>
        <property name="text">
@@ -553,7 +553,7 @@ border-radius: 15px;
         <x>560</x>
         <y>80</y>
         <width>111</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
      </widget>

--- a/App/view/ui/reserva.ui
+++ b/App/view/ui/reserva.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>863</width>
-    <height>651</height>
+    <width>865</width>
+    <height>655</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,8 +15,9 @@
   </property>
   <property name="styleSheet">
    <string notr="true">QLineEdit, QComboBox, QTimeEdit, QDateEdit {
-	background-color:rgba(0,0,0,0);
+	background-color: white;
 	border:2px solid rgba(0,0,0,0);
+	border-radius: 12px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;
@@ -25,12 +26,16 @@
 #btnFazerReserva {
 	background-color: #01498a;
 	color: #FFF;
-border: none;
-border-radius: 15px;
+	border: none;
+	border-radius: 15px;
 }
  
 #btnFazerReserva:hover {
 	background-color: #f6921e;
+}
+
+#observacaoReserva {
+	background-color: white;
 }
  
 #respostas {
@@ -88,11 +93,22 @@ border-radius: 15px;
      <widget class="QPushButton" name="btnFazerReserva">
       <property name="geometry">
        <rect>
-        <x>10</x>
+        <x>20</x>
         <y>570</y>
-        <width>811</width>
-        <height>41</height>
+        <width>801</width>
+        <height>47</height>
        </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>762</width>
+        <height>47</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>17</pointsize>
+       </font>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
@@ -118,7 +134,7 @@ border-radius: 15px;
       <property name="geometry">
        <rect>
         <x>320</x>
-        <y>68</y>
+        <y>66</y>
         <width>31</width>
         <height>16</height>
        </rect>
@@ -130,11 +146,16 @@ border-radius: 15px;
      <widget class="QLabel" name="label">
       <property name="geometry">
        <rect>
-        <x>340</x>
-        <y>20</y>
-        <width>101</width>
+        <x>310</x>
+        <y>10</y>
+        <width>151</width>
         <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>12</pointsize>
+       </font>
       </property>
       <property name="text">
        <string>RESERVA  DE SALA</string>
@@ -143,9 +164,9 @@ border-radius: 15px;
      <widget class="QLineEdit" name="observacaoReserva">
       <property name="geometry">
        <rect>
-        <x>20</x>
+        <x>30</x>
         <y>450</y>
-        <width>791</width>
+        <width>781</width>
         <height>101</height>
        </rect>
       </property>
@@ -222,9 +243,9 @@ border-radius: 15px;
       <property name="geometry">
        <rect>
         <x>320</x>
-        <y>90</y>
+        <y>91</y>
         <width>111</width>
-        <height>22</height>
+        <height>21</height>
        </rect>
       </property>
       <property name="cursor">

--- a/App/view/ui/reserva.ui
+++ b/App/view/ui/reserva.ui
@@ -17,7 +17,7 @@
    <string notr="true">QLineEdit, QComboBox, QTimeEdit, QDateEdit {
 	background-color: white;
 	border:2px solid rgba(0,0,0,0);
-	border-radius: 12px;
+	border-radius: 3px;
 	border-bottom-color:rgba(46,82,101,200);
 	color:rgb(0,0,0);
 	padding-bottom:7px;
@@ -55,7 +55,7 @@
       <property name="geometry">
        <rect>
         <x>560</x>
-        <y>67</y>
+        <y>60</y>
         <width>91</width>
         <height>16</height>
        </rect>
@@ -68,7 +68,7 @@
       <property name="geometry">
        <rect>
         <x>30</x>
-        <y>140</y>
+        <y>130</y>
         <width>41</width>
         <height>16</height>
        </rect>
@@ -121,7 +121,7 @@
       <property name="geometry">
        <rect>
         <x>30</x>
-        <y>68</y>
+        <y>60</y>
         <width>161</width>
         <height>16</height>
        </rect>
@@ -134,7 +134,7 @@
       <property name="geometry">
        <rect>
         <x>320</x>
-        <y>66</y>
+        <y>60</y>
         <width>31</width>
         <height>16</height>
        </rect>
@@ -207,9 +207,9 @@
       <property name="geometry">
        <rect>
         <x>560</x>
-        <y>92</y>
+        <y>82</y>
         <width>113</width>
-        <height>20</height>
+        <height>31</height>
        </rect>
       </property>
      </widget>
@@ -243,41 +243,41 @@
       <property name="geometry">
        <rect>
         <x>320</x>
-        <y>91</y>
+        <y>81</y>
         <width>111</width>
-        <height>21</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
       </property>
       <property name="editable">
-       <bool>true</bool>
+       <bool>false</bool>
       </property>
      </widget>
      <widget class="QComboBox" name="cursoReserva">
       <property name="geometry">
        <rect>
         <x>30</x>
-        <y>160</y>
+        <y>151</y>
         <width>161</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
       </property>
       <property name="editable">
-       <bool>true</bool>
+       <bool>false</bool>
       </property>
      </widget>
      <widget class="QComboBox" name="nomeDocente">
       <property name="geometry">
        <rect>
         <x>30</x>
-        <y>90</y>
+        <y>81</y>
         <width>161</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="cursor">
@@ -291,9 +291,9 @@
       <property name="geometry">
        <rect>
         <x>171</x>
-        <y>216</y>
+        <y>207</y>
         <width>81</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
      </widget>
@@ -301,9 +301,9 @@
       <property name="geometry">
        <rect>
         <x>171</x>
-        <y>267</y>
+        <y>257</y>
         <width>81</width>
-        <height>21</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="cursor">
@@ -314,16 +314,16 @@
       <property name="geometry">
        <rect>
         <x>320</x>
-        <y>160</y>
+        <y>151</y>
         <width>111</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
       </property>
       <property name="editable">
-       <bool>true</bool>
+       <bool>false</bool>
       </property>
       <item>
        <property name="text">
@@ -384,9 +384,9 @@
       <property name="geometry">
        <rect>
         <x>401</x>
-        <y>266</y>
+        <y>257</y>
         <width>118</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="cursor">
@@ -397,9 +397,9 @@
       <property name="geometry">
        <rect>
         <x>401</x>
-        <y>216</y>
+        <y>207</y>
         <width>118</width>
-        <height>22</height>
+        <height>31</height>
        </rect>
       </property>
       <property name="cursor">


### PR DESCRIPTION
### Alterações realizadas

- `ComboBox` arrumado em algumas telas para não ficar alterável.

- Campo 'alterar cadastro' removido da tela de editar pessoas por não ser necessário

**(VERSÃO ANTIGA!)**
![image](https://github.com/user-attachments/assets/29165ef9-5d9f-4b86-8f41-8d4bf4869a42)

- Ajustes de campos para ficarem com tamanho iguais.

- Calendário está visível ao ser clicado na tela de `cadastroPessoas.py`

![image](https://github.com/user-attachments/assets/f7109d03-a78f-4dbc-90ab-663dfd32405c)
