### PR TITLE
Modificação nas telas de Editar e Cadastro

### DIFF
--- a/App/view/ui/cadastroArea.ui
+++ b/App/view/ui/cadastroArea.ui
@@ -104,45 +104,31 @@ border-radius: 15px;
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QPushButton" name="btnCadastrarArea">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>47</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>17</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>Cadastrar</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnCadastrarArea">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>47</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>17</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Cadastrar</string>
+     </property>
     </widget>
    </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>cadastrarArea</tabstop>
-  <tabstop>btnCadastrarArea</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/App/view/ui/cadastroCurso.ui
+++ b/App/view/ui/cadastroCurso.ui
@@ -99,9 +99,9 @@ border-radius: 15px;
      <widget class="QLabel" name="label_7">
       <property name="geometry">
        <rect>
-        <x>70</x>
-        <y>200</y>
-        <width>131</width>
+        <x>30</x>
+        <y>190</y>
+        <width>111</width>
         <height>20</height>
        </rect>
       </property>
@@ -114,37 +114,11 @@ border-radius: 15px;
        <string>Período do Curso</string>
       </property>
      </widget>
-     <widget class="QLabel" name="respostaCadastroIncompleto">
-      <property name="geometry">
-       <rect>
-        <x>300</x>
-        <y>500</y>
-        <width>161</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-     <widget class="QLabel" name="respostaCadastrando">
-      <property name="geometry">
-       <rect>
-        <x>290</x>
-        <y>500</y>
-        <width>151</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
      <widget class="QComboBox" name="periodoCurso">
       <property name="geometry">
        <rect>
-        <x>70</x>
-        <y>231</y>
+        <x>30</x>
+        <y>221</y>
         <width>111</width>
         <height>41</height>
        </rect>
@@ -198,8 +172,8 @@ border-radius: 15px;
      <widget class="QLineEdit" name="cargaCurso">
       <property name="geometry">
        <rect>
-        <x>270</x>
-        <y>230</y>
+        <x>280</x>
+        <y>220</y>
         <width>231</width>
         <height>41</height>
        </rect>
@@ -222,7 +196,7 @@ border-radius: 15px;
      <widget class="QLineEdit" name="quantidadeAlunos">
       <property name="geometry">
        <rect>
-        <x>290</x>
+        <x>280</x>
         <y>340</y>
         <width>231</width>
         <height>41</height>

--- a/App/view/ui/cadastroPessoas.ui
+++ b/App/view/ui/cadastroPessoas.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>780</width>
-    <height>442</height>
+    <height>577</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,8 +37,13 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item alignment="Qt::AlignHCenter|Qt::AlignTop">
     <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <pointsize>13</pointsize>
+      </font>
+     </property>
      <property name="text">
-      <string>CADASTRO DE PESSOAS</string>
+      <string>Cadastro de Pessoas</string>
      </property>
      <property name="textFormat">
       <enum>Qt::AutoText</enum>
@@ -81,7 +86,7 @@
      <widget class="QLabel" name="label_3">
       <property name="geometry">
        <rect>
-        <x>360</x>
+        <x>460</x>
         <y>50</y>
         <width>61</width>
         <height>16</height>
@@ -107,7 +112,7 @@
      <widget class="QLabel" name="label_6">
       <property name="geometry">
        <rect>
-        <x>360</x>
+        <x>460</x>
         <y>120</y>
         <width>121</width>
         <height>16</height>
@@ -122,7 +127,7 @@
        <rect>
         <x>20</x>
         <y>180</y>
-        <width>55</width>
+        <width>51</width>
         <height>16</height>
        </rect>
       </property>
@@ -133,7 +138,7 @@
      <widget class="QLabel" name="label_7">
       <property name="geometry">
        <rect>
-        <x>330</x>
+        <x>460</x>
         <y>180</y>
         <width>71</width>
         <height>16</height>
@@ -162,9 +167,9 @@
      <widget class="QLineEdit" name="cpfCnpj">
       <property name="geometry">
        <rect>
-        <x>440</x>
+        <x>540</x>
         <y>41</y>
-        <width>151</width>
+        <width>161</width>
         <height>31</height>
        </rect>
       </property>
@@ -188,7 +193,7 @@
      <widget class="QDateEdit" name="dataDeNascimento">
       <property name="geometry">
        <rect>
-        <x>490</x>
+        <x>590</x>
         <y>111</y>
         <width>110</width>
         <height>31</height>
@@ -201,9 +206,9 @@
      <widget class="QLineEdit" name="telefone">
       <property name="geometry">
        <rect>
-        <x>410</x>
+        <x>540</x>
         <y>171</y>
-        <width>113</width>
+        <width>161</width>
         <height>31</height>
        </rect>
       </property>
@@ -214,7 +219,7 @@
      <widget class="QComboBox" name="cargo">
       <property name="geometry">
        <rect>
-        <x>100</x>
+        <x>80</x>
         <y>171</y>
         <width>101</width>
         <height>31</height>
@@ -259,14 +264,14 @@
      </property>
      <property name="font">
       <font>
-       <pointsize>17</pointsize>
+       <pointsize>15</pointsize>
       </font>
      </property>
      <property name="cursor">
       <cursorShape>PointingHandCursor</cursorShape>
      </property>
      <property name="text">
-      <string>CADASTRAR</string>
+      <string>Cadastrar</string>
      </property>
     </widget>
    </item>

--- a/App/view/ui/cadastroSalas.ui
+++ b/App/view/ui/cadastroSalas.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>662</width>
-    <height>611</height>
+    <width>819</width>
+    <height>664</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,7 +27,8 @@
 	background-color: #01498a;
 	color: #FFF;
 	border: none;
-	border-radius: 15px;
+	border-radius: 12px;
+
 }
  
 #cadastrarSala:hover {
@@ -38,280 +39,276 @@
 	color: red;
 }</string>
   </property>
-  <widget class="QPushButton" name="cadastrarSala">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>510</y>
-     <width>621</width>
-     <height>51</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>15</pointsize>
-    </font>
-   </property>
-   <property name="cursor">
-    <cursorShape>PointingHandCursor</cursorShape>
-   </property>
-   <property name="text">
-    <string>Cadastrar Sala</string>
-   </property>
-  </widget>
-  <widget class="QFrame" name="frame">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>40</y>
-     <width>621</width>
-     <height>461</height>
-    </rect>
-   </property>
-   <property name="frameShape">
-    <enum>QFrame::StyledPanel</enum>
-   </property>
-   <property name="frameShadow">
-    <enum>QFrame::Raised</enum>
-   </property>
-   <widget class="QLineEdit" name="feedbackText">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>330</y>
-      <width>601</width>
-      <height>101</height>
-     </rect>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
-    <property name="placeholderText">
-     <string>Observações adicionais</string>
-    </property>
-    <property name="cursorMoveStyle">
-     <enum>Qt::VisualMoveStyle</enum>
-    </property>
-    <property name="clearButtonEnabled">
-     <bool>false</bool>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_6">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>300</y>
-      <width>71</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Observações</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_5">
-    <property name="geometry">
-     <rect>
-      <x>21</x>
-      <y>150</y>
-      <width>65</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Capacidade</string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="mediaCapacidade">
-    <property name="geometry">
-     <rect>
-      <x>100</x>
-      <y>139</y>
-      <width>133</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-    </property>
-    <property name="placeholderText">
-     <string>Capacidade Média</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_4">
-    <property name="geometry">
-     <rect>
-      <x>310</x>
-      <y>80</y>
-      <width>71</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Equipamentos</string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="tipoEquipamento">
-    <property name="geometry">
-     <rect>
-      <x>389</x>
-      <y>69</y>
-      <width>133</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="placeholderText">
-     <string>Cadastrar Equipamentos</string>
-    </property>
-   </widget>
-   <widget class="QComboBox" name="nomePredio">
-    <property name="geometry">
-     <rect>
-      <x>99</x>
-      <y>69</y>
-      <width>81</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="cursor">
-     <cursorShape>PointingHandCursor</cursorShape>
-    </property>
-    <property name="editable">
-     <bool>false</bool>
-    </property>
-    <property name="currentText">
-     <string notr="true">Prédio 1</string>
-    </property>
-    <property name="insertPolicy">
-     <enum>QComboBox::InsertAlphabetically</enum>
-    </property>
-    <item>
-     <property name="text">
-      <string>Prédio 1</string>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item alignment="Qt::AlignHCenter|Qt::AlignBottom">
+    <widget class="QLabel" name="label_7">
+     <property name="font">
+      <font>
+       <pointsize>13</pointsize>
+      </font>
      </property>
-    </item>
-    <item>
      <property name="text">
-      <string>Prédio 2</string>
+      <string>Cadastro de Salas</string>
      </property>
-    </item>
-   </widget>
-   <widget class="QLabel" name="label_3">
-    <property name="geometry">
-     <rect>
-      <x>20</x>
-      <y>80</y>
-      <width>41</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Prédios</string>
-    </property>
-   </widget>
-   <widget class="QComboBox" name="tipoSala">
-    <property name="geometry">
-     <rect>
-      <x>400</x>
-      <y>9</y>
-      <width>81</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="cursor">
-     <cursorShape>PointingHandCursor</cursorShape>
-    </property>
-    <property name="editable">
-     <bool>false</bool>
-    </property>
-    <property name="currentText">
-     <string>Comum</string>
-    </property>
-    <property name="insertPolicy">
-     <enum>QComboBox::InsertAlphabetically</enum>
-    </property>
-    <property name="sizeAdjustPolicy">
-     <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-    </property>
-    <item>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <widget class="QLabel" name="label_5">
+      <property name="geometry">
+       <rect>
+        <x>21</x>
+        <y>150</y>
+        <width>65</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Capacidade</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="mediaCapacidade">
+      <property name="geometry">
+       <rect>
+        <x>100</x>
+        <y>139</y>
+        <width>231</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
+      <property name="placeholderText">
+       <string>Capacidade Média</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_4">
+      <property name="geometry">
+       <rect>
+        <x>440</x>
+        <y>80</y>
+        <width>71</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Equipamentos</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="tipoEquipamento">
+      <property name="geometry">
+       <rect>
+        <x>519</x>
+        <y>69</y>
+        <width>231</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="placeholderText">
+       <string>Cadastrar Equipamentos</string>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="nomePredio">
+      <property name="geometry">
+       <rect>
+        <x>99</x>
+        <y>69</y>
+        <width>231</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
+      </property>
+      <property name="editable">
+       <bool>false</bool>
+      </property>
+      <property name="currentText">
+       <string notr="true">Prédio 1</string>
+      </property>
+      <property name="insertPolicy">
+       <enum>QComboBox::InsertAlphabetically</enum>
+      </property>
+      <item>
+       <property name="text">
+        <string>Prédio 1</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Prédio 2</string>
+       </property>
+      </item>
+     </widget>
+     <widget class="QLabel" name="label_3">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>80</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Prédios</string>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="tipoSala">
+      <property name="geometry">
+       <rect>
+        <x>520</x>
+        <y>9</y>
+        <width>231</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
+      </property>
+      <property name="editable">
+       <bool>false</bool>
+      </property>
+      <property name="currentText">
+       <string>Comum</string>
+      </property>
+      <property name="insertPolicy">
+       <enum>QComboBox::InsertAlphabetically</enum>
+      </property>
+      <property name="sizeAdjustPolicy">
+       <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+      </property>
+      <item>
+       <property name="text">
+        <string>Comum</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Laboratório</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Comum</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Área Externa</string>
+       </property>
+      </item>
+     </widget>
+     <widget class="QLabel" name="label_2">
+      <property name="geometry">
+       <rect>
+        <x>440</x>
+        <y>20</y>
+        <width>65</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Tipo de Sala</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>20</y>
+        <width>65</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Nome da Sala</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="nomeSala">
+      <property name="geometry">
+       <rect>
+        <x>100</x>
+        <y>8</y>
+        <width>231</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="placeholderText">
+       <string>Nome da Sala</string>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Comum</string>
+      <string>Observações</string>
      </property>
-    </item>
-    <item>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="feedbackText">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>721</width>
+       <height>201</height>
+      </size>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="placeholderText">
+      <string>Observações adicionais</string>
+     </property>
+     <property name="cursorMoveStyle">
+      <enum>Qt::VisualMoveStyle</enum>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="cadastrarSala">
+     <property name="minimumSize">
+      <size>
+       <width>762</width>
+       <height>47</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>15</pointsize>
+      </font>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
      <property name="text">
-      <string>Laboratório</string>
+      <string>Cadastrar Sala</string>
      </property>
-    </item>
-    <item>
-     <property name="text">
-      <string>Comum</string>
-     </property>
-    </item>
-    <item>
-     <property name="text">
-      <string>Área Externa</string>
-     </property>
-    </item>
-   </widget>
-   <widget class="QLabel" name="label_2">
-    <property name="geometry">
-     <rect>
-      <x>310</x>
-      <y>20</y>
-      <width>65</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Tipo de Sala</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>20</x>
-      <y>20</y>
-      <width>65</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Nome da Sala</string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="nomeSala">
-    <property name="geometry">
-     <rect>
-      <x>100</x>
-      <y>8</y>
-      <width>133</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="placeholderText">
-     <string>Nome da Sala</string>
-    </property>
-   </widget>
-  </widget>
-  <widget class="QLabel" name="label_7">
-   <property name="geometry">
-    <rect>
-     <x>233</x>
-     <y>10</y>
-     <width>141</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>13</pointsize>
-    </font>
-   </property>
-   <property name="text">
-    <string>Cadastro de Salas</string>
-   </property>
-  </widget>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <tabstops>
   <tabstop>nomeSala</tabstop>

--- a/App/view/ui/editarArea.ui
+++ b/App/view/ui/editarArea.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>770</width>
+    <width>780</width>
     <height>679</height>
    </rect>
   </property>
@@ -42,126 +42,97 @@
 	color: red;
 }</string>
   </property>
-  <widget class="QFrame" name="frame_2">
-   <property name="geometry">
-    <rect>
-     <x>9</x>
-     <y>9</y>
-     <width>752</width>
-     <height>311</height>
-    </rect>
-   </property>
-   <property name="frameShape">
-    <enum>QFrame::StyledPanel</enum>
-   </property>
-   <property name="frameShadow">
-    <enum>QFrame::Raised</enum>
-   </property>
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>330</x>
-      <y>10</y>
-      <width>91</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="font">
-     <font>
-      <pointsize>12</pointsize>
-     </font>
-    </property>
-    <property name="text">
-     <string>Editar Área</string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="cadastrarArea">
-    <property name="geometry">
-     <rect>
-      <x>230</x>
-      <y>219</y>
-      <width>291</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
-    <property name="placeholderText">
-     <string>Editar Área</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="respostaCadastrando">
-    <property name="geometry">
-     <rect>
-      <x>280</x>
-      <y>400</y>
-      <width>211</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QLabel" name="respostaNaoCadastrado">
-    <property name="geometry">
-     <rect>
-      <x>280</x>
-      <y>400</y>
-      <width>211</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QComboBox" name="alterarArea">
-    <property name="geometry">
-     <rect>
-      <x>540</x>
-      <y>120</y>
-      <width>69</width>
-      <height>22</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_2">
-    <property name="geometry">
-     <rect>
-      <x>540</x>
-      <y>80</y>
-      <width>71</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Alterar Area:</string>
-    </property>
-   </widget>
-  </widget>
-  <widget class="QPushButton" name="btnEditarArea">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>330</y>
-     <width>751</width>
-     <height>51</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>15</pointsize>
-    </font>
-   </property>
-   <property name="cursor">
-    <cursorShape>PointingHandCursor</cursorShape>
-   </property>
-   <property name="text">
-    <string>Salvar Alterações</string>
-   </property>
-  </widget>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QFrame" name="frame_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+       <widget class="QLabel" name="label">
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>Editar Área</string>
+        </property>
+       </widget>
+      </item>
+      <item alignment="Qt::AlignLeft|Qt::AlignBottom">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Alterar Area:</string>
+        </property>
+       </widget>
+      </item>
+      <item alignment="Qt::AlignLeft">
+       <widget class="QComboBox" name="alterarArea">
+        <property name="minimumSize">
+         <size>
+          <width>130</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="cadastrarArea">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>47</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="placeholderText">
+         <string>Editar Área</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnEditarArea">
+     <property name="minimumSize">
+      <size>
+       <width>762</width>
+       <height>47</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>17</pointsize>
+      </font>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="text">
+      <string>Salvar Alterações</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/App/view/ui/editarCurso.ui
+++ b/App/view/ui/editarCurso.ui
@@ -42,316 +42,286 @@
 	color: red;
 }</string>
   </property>
-  <widget class="QFrame" name="frame_2">
-   <property name="geometry">
-    <rect>
-     <x>14</x>
-     <y>9</y>
-     <width>801</width>
-     <height>441</height>
-    </rect>
-   </property>
-   <property name="frameShape">
-    <enum>QFrame::StyledPanel</enum>
-   </property>
-   <property name="frameShadow">
-    <enum>QFrame::Raised</enum>
-   </property>
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>330</x>
-      <y>10</y>
-      <width>121</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="font">
-     <font>
-      <pointsize>12</pointsize>
-     </font>
-    </property>
-    <property name="text">
-     <string>EDITAR CURSO</string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="nomeCurso">
-    <property name="geometry">
-     <rect>
-      <x>70</x>
-      <y>129</y>
-      <width>113</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="placeholderText">
-     <string>Nome do Curso</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_2">
-    <property name="geometry">
-     <rect>
-      <x>70</x>
-      <y>106</y>
-      <width>81</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Nome do Curso</string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="quantidadeAlunos">
-    <property name="geometry">
-     <rect>
-      <x>320</x>
-      <y>360</y>
-      <width>131</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="placeholderText">
-     <string>Quantidade de Alunos </string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="ofertaCurso">
-    <property name="geometry">
-     <rect>
-      <x>320</x>
-      <y>129</y>
-      <width>131</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="placeholderText">
-     <string>Oferta do Curso</string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="horasPorDia">
-    <property name="geometry">
-     <rect>
-      <x>70</x>
-      <y>359</y>
-      <width>113</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="placeholderText">
-     <string>Horário do Curso</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_3">
-    <property name="geometry">
-     <rect>
-      <x>320</x>
-      <y>215</y>
-      <width>71</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Carga Horária</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_4">
-    <property name="geometry">
-     <rect>
-      <x>320</x>
-      <y>103</y>
-      <width>47</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Oferta</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_5">
-    <property name="geometry">
-     <rect>
-      <x>320</x>
-      <y>336</y>
-      <width>111</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Quantidade de Alunos</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_6">
-    <property name="geometry">
-     <rect>
-      <x>70</x>
-      <y>333</y>
-      <width>81</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Horas por Dia</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_7">
-    <property name="geometry">
-     <rect>
-      <x>70</x>
-      <y>213</y>
-      <width>91</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Período do Curso</string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="cargaCurso">
-    <property name="geometry">
-     <rect>
-      <x>320</x>
-      <y>239</y>
-      <width>131</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="placeholderText">
-     <string>Carga Horária do Curso</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="respostaCadastroIncompleto">
-    <property name="geometry">
-     <rect>
-      <x>290</x>
-      <y>500</y>
-      <width>201</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QLabel" name="respostaCadastrando">
-    <property name="geometry">
-     <rect>
-      <x>290</x>
-      <y>500</y>
-      <width>201</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QComboBox" name="periodoCurso">
-    <property name="geometry">
-     <rect>
-      <x>70</x>
-      <y>241</y>
-      <width>81</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="cursor">
-     <cursorShape>PointingHandCursor</cursorShape>
-    </property>
-    <property name="editable">
-     <bool>false</bool>
-    </property>
-    <item>
-     <property name="text">
-      <string>Manhã</string>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
      </property>
-    </item>
-    <item>
      <property name="text">
-      <string>Tarde</string>
+      <string>Editar Curso</string>
      </property>
-    </item>
-    <item>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <widget class="QLineEdit" name="nomeCurso">
+      <property name="geometry">
+       <rect>
+        <x>70</x>
+        <y>129</y>
+        <width>131</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="placeholderText">
+       <string>Nome do Curso</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_2">
+      <property name="geometry">
+       <rect>
+        <x>70</x>
+        <y>106</y>
+        <width>81</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Nome do Curso</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="quantidadeAlunos">
+      <property name="geometry">
+       <rect>
+        <x>340</x>
+        <y>360</y>
+        <width>141</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="placeholderText">
+       <string>Quantidade de Alunos </string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="ofertaCurso">
+      <property name="geometry">
+       <rect>
+        <x>340</x>
+        <y>129</y>
+        <width>141</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="placeholderText">
+       <string>Oferta do Curso</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="horasPorDia">
+      <property name="geometry">
+       <rect>
+        <x>70</x>
+        <y>359</y>
+        <width>131</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="placeholderText">
+       <string>Horário do Curso</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_3">
+      <property name="geometry">
+       <rect>
+        <x>340</x>
+        <y>215</y>
+        <width>71</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Carga Horária</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_4">
+      <property name="geometry">
+       <rect>
+        <x>340</x>
+        <y>103</y>
+        <width>47</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Oferta</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_5">
+      <property name="geometry">
+       <rect>
+        <x>340</x>
+        <y>336</y>
+        <width>111</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Quantidade de Alunos</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_6">
+      <property name="geometry">
+       <rect>
+        <x>70</x>
+        <y>333</y>
+        <width>81</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Horas por Dia</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_7">
+      <property name="geometry">
+       <rect>
+        <x>70</x>
+        <y>213</y>
+        <width>91</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Período do Curso</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="cargaCurso">
+      <property name="geometry">
+       <rect>
+        <x>340</x>
+        <y>239</y>
+        <width>141</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="placeholderText">
+       <string>Carga Horária do Curso</string>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="periodoCurso">
+      <property name="geometry">
+       <rect>
+        <x>70</x>
+        <y>241</y>
+        <width>101</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
+      </property>
+      <property name="editable">
+       <bool>false</bool>
+      </property>
+      <item>
+       <property name="text">
+        <string>Manhã</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Tarde</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Noite</string>
+       </property>
+      </item>
+     </widget>
+     <widget class="QComboBox" name="campoArea">
+      <property name="geometry">
+       <rect>
+        <x>600</x>
+        <y>130</y>
+        <width>121</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
+      </property>
+      <property name="editable">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_8">
+      <property name="geometry">
+       <rect>
+        <x>600</x>
+        <y>92</y>
+        <width>51</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Área</string>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="alterarCurso">
+      <property name="geometry">
+       <rect>
+        <x>600</x>
+        <y>241</y>
+        <width>121</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_9">
+      <property name="geometry">
+       <rect>
+        <x>600</x>
+        <y>220</y>
+        <width>71</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Alterar Curso</string>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnEditarCurso">
+     <property name="minimumSize">
+      <size>
+       <width>762</width>
+       <height>47</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>17</pointsize>
+      </font>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
      <property name="text">
-      <string>Noite</string>
+      <string>Editar Curso</string>
      </property>
-    </item>
-   </widget>
-   <widget class="QComboBox" name="campoArea">
-    <property name="geometry">
-     <rect>
-      <x>580</x>
-      <y>130</y>
-      <width>69</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="cursor">
-     <cursorShape>PointingHandCursor</cursorShape>
-    </property>
-    <property name="editable">
-     <bool>false</bool>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_8">
-    <property name="geometry">
-     <rect>
-      <x>580</x>
-      <y>92</y>
-      <width>51</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Área</string>
-    </property>
-   </widget>
-   <widget class="QComboBox" name="alterarCurso">
-    <property name="geometry">
-     <rect>
-      <x>580</x>
-      <y>241</y>
-      <width>69</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="cursor">
-     <cursorShape>PointingHandCursor</cursorShape>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_9">
-    <property name="geometry">
-     <rect>
-      <x>580</x>
-      <y>220</y>
-      <width>71</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Alterar Curso</string>
-    </property>
-   </widget>
-  </widget>
-  <widget class="QPushButton" name="btnEditarCurso">
-   <property name="geometry">
-    <rect>
-     <x>14</x>
-     <y>460</y>
-     <width>801</width>
-     <height>41</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>12</pointsize>
-    </font>
-   </property>
-   <property name="cursor">
-    <cursorShape>PointingHandCursor</cursorShape>
-   </property>
-   <property name="text">
-    <string>EDITAR CURSO</string>
-   </property>
-  </widget>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/App/view/ui/editarLogin.ui
+++ b/App/view/ui/editarLogin.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>686</width>
+    <width>851</width>
     <height>680</height>
    </rect>
   </property>
@@ -38,157 +38,158 @@
 	color: red;
 }</string>
   </property>
-  <widget class="QFrame" name="frame_2">
-   <property name="geometry">
-    <rect>
-     <x>9</x>
-     <y>9</y>
-     <width>661</width>
-     <height>311</height>
-    </rect>
-   </property>
-   <property name="frameShape">
-    <enum>QFrame::StyledPanel</enum>
-   </property>
-   <property name="frameShadow">
-    <enum>QFrame::Raised</enum>
-   </property>
-   <widget class="QLineEdit" name="email">
-    <property name="geometry">
-     <rect>
-      <x>20</x>
-      <y>109</y>
-      <width>113</width>
-      <height>31</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="senha">
-    <property name="geometry">
-     <rect>
-      <x>270</x>
-      <y>109</y>
-      <width>113</width>
-      <height>31</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QComboBox" name="nivelAcesso">
-    <property name="geometry">
-     <rect>
-      <x>30</x>
-      <y>241</y>
-      <width>69</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="cursor">
-     <cursorShape>PointingHandCursor</cursorShape>
-    </property>
-    <property name="editable">
-     <bool>false</bool>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>20</x>
-      <y>80</y>
-      <width>41</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Email</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_2">
-    <property name="geometry">
-     <rect>
-      <x>270</x>
-      <y>80</y>
-      <width>41</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Senha</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_3">
-    <property name="geometry">
-     <rect>
-      <x>30</x>
-      <y>210</y>
-      <width>81</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Nivel de Acesso</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_4">
-    <property name="geometry">
-     <rect>
-      <x>290</x>
-      <y>10</y>
-      <width>81</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>EDITAR LOGIN</string>
-    </property>
-   </widget>
-   <widget class="QComboBox" name="alterarLogin">
-    <property name="geometry">
-     <rect>
-      <x>500</x>
-      <y>110</y>
-      <width>71</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="cursor">
-     <cursorShape>PointingHandCursor</cursorShape>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_5">
-    <property name="geometry">
-     <rect>
-      <x>500</x>
-      <y>78</y>
-      <width>71</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Alterar Login:</string>
-    </property>
-   </widget>
-  </widget>
-  <widget class="QPushButton" name="btnEditarLogin">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>330</y>
-     <width>661</width>
-     <height>61</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>12</pointsize>
-    </font>
-   </property>
-   <property name="cursor">
-    <cursorShape>PointingHandCursor</cursorShape>
-   </property>
-   <property name="text">
-    <string>Editar Login</string>
-   </property>
-  </widget>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+    <widget class="QLabel" name="label_4">
+     <property name="font">
+      <font>
+       <pointsize>13</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Editar Login</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <widget class="QLineEdit" name="email">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>110</y>
+        <width>161</width>
+        <height>31</height>
+       </rect>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="senha">
+      <property name="geometry">
+       <rect>
+        <x>320</x>
+        <y>109</y>
+        <width>161</width>
+        <height>31</height>
+       </rect>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="nivelAcesso">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>240</y>
+        <width>161</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
+      </property>
+      <property name="editable">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>80</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Email</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_2">
+      <property name="geometry">
+       <rect>
+        <x>320</x>
+        <y>80</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Senha</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_3">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>210</y>
+        <width>81</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Nivel de Acesso</string>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="alterarLogin">
+      <property name="geometry">
+       <rect>
+        <x>640</x>
+        <y>110</y>
+        <width>161</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_5">
+      <property name="geometry">
+       <rect>
+        <x>640</x>
+        <y>78</y>
+        <width>71</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Alterar Login:</string>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnEditarLogin">
+     <property name="minimumSize">
+      <size>
+       <width>762</width>
+       <height>47</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>17</pointsize>
+      </font>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="text">
+      <string>Editar Login</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <tabstops>
   <tabstop>email</tabstop>

--- a/App/view/ui/editarPessoa.ui
+++ b/App/view/ui/editarPessoa.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>744</width>
+    <width>821</width>
     <height>662</height>
    </rect>
   </property>
@@ -38,234 +38,230 @@ border-radius: 15px;
 	color: red;
 }</string>
   </property>
-  <widget class="QFrame" name="frame">
-   <property name="geometry">
-    <rect>
-     <x>9</x>
-     <y>9</y>
-     <width>721</width>
-     <height>461</height>
-    </rect>
-   </property>
-   <property name="frameShape">
-    <enum>QFrame::StyledPanel</enum>
-   </property>
-   <property name="frameShadow">
-    <enum>QFrame::Raised</enum>
-   </property>
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>260</x>
-      <y>10</y>
-      <width>161</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>EDITAR CADASTRO DE PESSOAS</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_2">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>80</y>
-      <width>41</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>NOME:</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_3">
-    <property name="geometry">
-     <rect>
-      <x>350</x>
-      <y>80</y>
-      <width>61</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>CPF/CNPJ:</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_4">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>150</y>
-      <width>41</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>EMAIL:</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_6">
-    <property name="geometry">
-     <rect>
-      <x>350</x>
-      <y>150</y>
-      <width>121</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>DATA DE NASCIMENTO:</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_5">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>216</y>
-      <width>55</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>CARGO:</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_7">
-    <property name="geometry">
-     <rect>
-      <x>230</x>
-      <y>213</y>
-      <width>71</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>TELEFONE:</string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="nomePessoas">
-    <property name="geometry">
-     <rect>
-      <x>70</x>
-      <y>71</y>
-      <width>251</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="cpfCnpj">
-    <property name="geometry">
-     <rect>
-      <x>430</x>
-      <y>71</y>
-      <width>151</width>
-      <height>31</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="email">
-    <property name="geometry">
-     <rect>
-      <x>70</x>
-      <y>141</y>
-      <width>251</width>
-      <height>31</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QDateEdit" name="dataDeNascimento">
-    <property name="geometry">
-     <rect>
-      <x>490</x>
-      <y>138</y>
-      <width>110</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="cursor">
-     <cursorShape>PointingHandCursor</cursorShape>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="telefone">
-    <property name="geometry">
-     <rect>
-      <x>310</x>
-      <y>205</y>
-      <width>113</width>
-      <height>31</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QComboBox" name="cargo">
-    <property name="geometry">
-     <rect>
-      <x>70</x>
-      <y>206</y>
-      <width>101</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="cursor">
-     <cursorShape>PointingHandCursor</cursorShape>
-    </property>
-    <property name="editable">
-     <bool>false</bool>
-    </property>
-    <item>
-     <property name="text">
-      <string>Comum</string>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item alignment="Qt::AlignHCenter|Qt::AlignBottom">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
      </property>
-    </item>
-    <item>
      <property name="text">
-      <string>Apoio</string>
+      <string>Editar Cadastro de Pessoas</string>
      </property>
-    </item>
-    <item>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <widget class="QLabel" name="label_2">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>80</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>NOME:</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_3">
+      <property name="geometry">
+       <rect>
+        <x>530</x>
+        <y>80</y>
+        <width>61</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>CPF/CNPJ:</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_4">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>150</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>EMAIL:</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_6">
+      <property name="geometry">
+       <rect>
+        <x>530</x>
+        <y>150</y>
+        <width>121</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>DATA DE NASCIMENTO:</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_5">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>216</y>
+        <width>55</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>CARGO:</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_7">
+      <property name="geometry">
+       <rect>
+        <x>530</x>
+        <y>213</y>
+        <width>61</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>TELEFONE:</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="nomePessoas">
+      <property name="geometry">
+       <rect>
+        <x>70</x>
+        <y>71</y>
+        <width>251</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="cpfCnpj">
+      <property name="geometry">
+       <rect>
+        <x>610</x>
+        <y>71</y>
+        <width>151</width>
+        <height>31</height>
+       </rect>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="email">
+      <property name="geometry">
+       <rect>
+        <x>70</x>
+        <y>141</y>
+        <width>251</width>
+        <height>31</height>
+       </rect>
+      </property>
+     </widget>
+     <widget class="QDateEdit" name="dataDeNascimento">
+      <property name="geometry">
+       <rect>
+        <x>650</x>
+        <y>138</y>
+        <width>110</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="telefone">
+      <property name="geometry">
+       <rect>
+        <x>610</x>
+        <y>205</y>
+        <width>151</width>
+        <height>31</height>
+       </rect>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="cargo">
+      <property name="geometry">
+       <rect>
+        <x>70</x>
+        <y>206</y>
+        <width>101</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
+      </property>
+      <property name="editable">
+       <bool>false</bool>
+      </property>
+      <item>
+       <property name="text">
+        <string>Comum</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Apoio</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Patrimonio</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Administrador</string>
+       </property>
+      </item>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnEditar">
+     <property name="minimumSize">
+      <size>
+       <width>762</width>
+       <height>47</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>17</pointsize>
+      </font>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
      <property name="text">
-      <string>Patrimonio</string>
+      <string>Editar Cadastro</string>
      </property>
-    </item>
-    <item>
-     <property name="text">
-      <string>Administrador</string>
-     </property>
-    </item>
-   </widget>
-  </widget>
-  <widget class="QPushButton" name="btnEditar">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>480</y>
-     <width>721</width>
-     <height>41</height>
-    </rect>
-   </property>
-   <property name="cursor">
-    <cursorShape>PointingHandCursor</cursorShape>
-   </property>
-   <property name="text">
-    <string>EDITAR</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="respostaCadastro">
-   <property name="geometry">
-    <rect>
-     <x>240</x>
-     <y>510</y>
-     <width>141</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string/>
-   </property>
-  </widget>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <tabstops>
   <tabstop>nomePessoas</tabstop>

--- a/App/view/ui/editarReserva.ui
+++ b/App/view/ui/editarReserva.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>813</width>
-    <height>738</height>
+    <width>1148</width>
+    <height>870</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,14 +33,62 @@ border-radius: 15px;
 #btnEditarReserva:hover {
 	background-color: #f6921e;
 }
+
+#segunda {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
+
+#terca {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
+
+#quarta {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
+
+#quinta {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
+
+#sexta {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
+
+#sabado {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
  
 #respostas {
 	color: red;
 }</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <pointsize>13</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Editar Reserva de Sala</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QFrame" name="ReservaDeSala">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
      </property>
@@ -50,7 +98,7 @@ border-radius: 15px;
      <widget class="QLabel" name="label_4">
       <property name="geometry">
        <rect>
-        <x>20</x>
+        <x>80</x>
         <y>128</y>
         <width>91</width>
         <height>16</height>
@@ -63,8 +111,8 @@ border-radius: 15px;
      <widget class="QLabel" name="label_2">
       <property name="geometry">
        <rect>
-        <x>320</x>
-        <y>120</y>
+        <x>490</x>
+        <y>130</y>
         <width>41</width>
         <height>16</height>
        </rect>
@@ -76,8 +124,8 @@ border-radius: 15px;
      <widget class="QLabel" name="label_6">
       <property name="geometry">
        <rect>
-        <x>560</x>
-        <y>120</y>
+        <x>860</x>
+        <y>130</y>
         <width>61</width>
         <height>16</height>
        </rect>
@@ -86,32 +134,11 @@ border-radius: 15px;
        <string>PERIODO:</string>
       </property>
      </widget>
-     <widget class="QPushButton" name="btnEditarReserva">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>650</y>
-        <width>761</width>
-        <height>51</height>
-       </rect>
-      </property>
-      <property name="font">
-       <font>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="cursor">
-       <cursorShape>PointingHandCursor</cursorShape>
-      </property>
-      <property name="text">
-       <string>EDITAR RESERVA</string>
-      </property>
-     </widget>
      <widget class="QLabel" name="nomeDocenteResponsavel">
       <property name="geometry">
        <rect>
-        <x>20</x>
-        <y>60</y>
+        <x>80</x>
+        <y>50</y>
         <width>161</width>
         <height>16</height>
        </rect>
@@ -123,56 +150,14 @@ border-radius: 15px;
      <widget class="QLabel" name="label_3">
       <property name="geometry">
        <rect>
-        <x>320</x>
-        <y>60</y>
+        <x>490</x>
+        <y>50</y>
         <width>31</width>
         <height>16</height>
        </rect>
       </property>
       <property name="text">
        <string>SALA:</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label">
-      <property name="geometry">
-       <rect>
-        <x>300</x>
-        <y>10</y>
-        <width>141</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>EDITAR RESERVA  DE SALA</string>
-      </property>
-     </widget>
-     <widget class="QLineEdit" name="observacaoReserva">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>530</y>
-        <width>741</width>
-        <height>101</height>
-       </rect>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignCenter</set>
-      </property>
-      <property name="placeholderText">
-       <string>OBSERVAÇÕES A SEREM ACRESCENTADAS</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label_7">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>500</y>
-        <width>81</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>OBSERVAÇÕES:</string>
       </property>
      </widget>
      <widget class="QLabel" name="feedbackReserva">
@@ -191,9 +176,9 @@ border-radius: 15px;
      <widget class="QLineEdit" name="equipamentosReserva">
       <property name="geometry">
        <rect>
-        <x>20</x>
+        <x>80</x>
         <y>150</y>
-        <width>161</width>
+        <width>171</width>
         <height>31</height>
        </rect>
       </property>
@@ -201,8 +186,8 @@ border-radius: 15px;
      <widget class="QLabel" name="label_5">
       <property name="geometry">
        <rect>
-        <x>20</x>
-        <y>220</y>
+        <x>250</x>
+        <y>230</y>
         <width>131</width>
         <height>20</height>
        </rect>
@@ -214,8 +199,8 @@ border-radius: 15px;
      <widget class="QLabel" name="label_8">
       <property name="geometry">
        <rect>
-        <x>20</x>
-        <y>280</y>
+        <x>250</x>
+        <y>290</y>
         <width>121</width>
         <height>21</height>
        </rect>
@@ -227,11 +212,14 @@ border-radius: 15px;
      <widget class="QComboBox" name="salaReserva">
       <property name="geometry">
        <rect>
-        <x>320</x>
-        <y>80</y>
-        <width>111</width>
+        <x>490</x>
+        <y>70</y>
+        <width>131</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
       </property>
       <property name="editable">
        <bool>true</bool>
@@ -240,11 +228,14 @@ border-radius: 15px;
      <widget class="QComboBox" name="cursoReserva">
       <property name="geometry">
        <rect>
-        <x>320</x>
+        <x>490</x>
         <y>147</y>
-        <width>111</width>
+        <width>131</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
       </property>
       <property name="editable">
        <bool>true</bool>
@@ -253,11 +244,14 @@ border-radius: 15px;
      <widget class="QComboBox" name="nomeDocente">
       <property name="geometry">
        <rect>
-        <x>20</x>
-        <y>80</y>
-        <width>161</width>
+        <x>80</x>
+        <y>70</y>
+        <width>171</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
       </property>
       <property name="editable">
        <bool>true</bool>
@@ -266,31 +260,40 @@ border-radius: 15px;
      <widget class="QDateEdit" name="diaInicio">
       <property name="geometry">
        <rect>
-        <x>160</x>
-        <y>211</y>
+        <x>390</x>
+        <y>221</y>
         <width>81</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
       </property>
      </widget>
      <widget class="QDateEdit" name="diaFim">
       <property name="geometry">
        <rect>
-        <x>160</x>
-        <y>271</y>
+        <x>390</x>
+        <y>281</y>
         <width>81</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
       </property>
      </widget>
      <widget class="QComboBox" name="periodoReserva">
       <property name="geometry">
        <rect>
-        <x>560</x>
+        <x>860</x>
         <y>147</y>
-        <width>111</width>
+        <width>121</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
       </property>
       <property name="editable">
        <bool>false</bool>
@@ -314,8 +317,8 @@ border-radius: 15px;
      <widget class="QLabel" name="label_9">
       <property name="geometry">
        <rect>
-        <x>90</x>
-        <y>360</y>
+        <x>80</x>
+        <y>320</y>
         <width>91</width>
         <height>16</height>
        </rect>
@@ -327,8 +330,8 @@ border-radius: 15px;
      <widget class="QLabel" name="label_10">
       <property name="geometry">
        <rect>
-        <x>280</x>
-        <y>220</y>
+        <x>510</x>
+        <y>230</y>
         <width>91</width>
         <height>16</height>
        </rect>
@@ -340,8 +343,8 @@ border-radius: 15px;
      <widget class="QLabel" name="label_11">
       <property name="geometry">
        <rect>
-        <x>280</x>
-        <y>280</y>
+        <x>510</x>
+        <y>290</y>
         <width>91</width>
         <height>16</height>
        </rect>
@@ -353,35 +356,41 @@ border-radius: 15px;
      <widget class="QTimeEdit" name="fimCurso">
       <property name="geometry">
        <rect>
-        <x>390</x>
-        <y>270</y>
+        <x>620</x>
+        <y>280</y>
         <width>118</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
       </property>
      </widget>
      <widget class="QTimeEdit" name="inicioCurso">
       <property name="geometry">
        <rect>
-        <x>390</x>
-        <y>208</y>
+        <x>620</x>
+        <y>218</y>
         <width>118</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
       </property>
      </widget>
      <widget class="QWidget" name="widget_8" native="true">
       <property name="geometry">
        <rect>
-        <x>90</x>
-        <y>386</y>
-        <width>521</width>
-        <height>91</height>
+        <x>80</x>
+        <y>350</y>
+        <width>861</width>
+        <height>101</height>
        </rect>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="QWidget" name="widget_9" native="true">
+        <widget class="QWidget" name="segunda" native="true">
          <layout class="QVBoxLayout" name="verticalLayout_13">
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -408,7 +417,7 @@ border-radius: 15px;
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget_4" native="true">
+        <widget class="QWidget" name="terca" native="true">
          <layout class="QVBoxLayout" name="verticalLayout_9">
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -435,7 +444,7 @@ border-radius: 15px;
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget_5" native="true">
+        <widget class="QWidget" name="quarta" native="true">
          <layout class="QVBoxLayout" name="verticalLayout_10">
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -462,7 +471,7 @@ border-radius: 15px;
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget_3" native="true">
+        <widget class="QWidget" name="quinta" native="true">
          <layout class="QVBoxLayout" name="verticalLayout_8">
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -489,7 +498,7 @@ border-radius: 15px;
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget_6" native="true">
+        <widget class="QWidget" name="sexta" native="true">
          <layout class="QVBoxLayout" name="verticalLayout_11">
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -516,7 +525,7 @@ border-radius: 15px;
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget_7" native="true">
+        <widget class="QWidget" name="sabado" native="true">
          <property name="tabletTracking">
           <bool>false</bool>
          </property>
@@ -550,17 +559,20 @@ border-radius: 15px;
      <widget class="QComboBox" name="alterarReserva">
       <property name="geometry">
        <rect>
-        <x>560</x>
-        <y>80</y>
-        <width>111</width>
+        <x>860</x>
+        <y>70</y>
+        <width>121</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
       </property>
      </widget>
      <widget class="QLabel" name="label_13">
       <property name="geometry">
        <rect>
-        <x>560</x>
+        <x>860</x>
         <y>50</y>
         <width>131</width>
         <height>16</height>
@@ -570,6 +582,50 @@ border-radius: 15px;
        <string>Alterar Reserva de Salas:</string>
       </property>
      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>OBSERVAÇÕES:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="observacaoReserva">
+     <property name="minimumSize">
+      <size>
+       <width>721</width>
+       <height>125</height>
+      </size>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="placeholderText">
+      <string>OBSERVAÇÕES A SEREM ACRESCENTADAS</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnEditarReserva">
+     <property name="minimumSize">
+      <size>
+       <width>762</width>
+       <height>47</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>17</pointsize>
+      </font>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="text">
+      <string>EDITAR RESERVA</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/App/view/ui/editarSalas.ui
+++ b/App/view/ui/editarSalas.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>639</width>
-    <height>541</height>
+    <width>812</width>
+    <height>556</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,8 +37,13 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item alignment="Qt::AlignHCenter|Qt::AlignTop">
     <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <pointsize>13</pointsize>
+      </font>
+     </property>
      <property name="text">
-      <string>EDITAR SALA</string>
+      <string>Editar Sala</string>
      </property>
     </widget>
    </item>
@@ -56,46 +61,11 @@
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <widget class="QLineEdit" name="feedbackText">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>330</y>
-        <width>601</width>
-        <height>101</height>
-       </rect>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignCenter</set>
-      </property>
-      <property name="placeholderText">
-       <string>Observações adicionais</string>
-      </property>
-      <property name="cursorMoveStyle">
-       <enum>Qt::VisualMoveStyle</enum>
-      </property>
-      <property name="clearButtonEnabled">
-       <bool>false</bool>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label_6">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>300</y>
-        <width>71</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Observações</string>
-      </property>
-     </widget>
      <widget class="QLabel" name="label_5">
       <property name="geometry">
        <rect>
-        <x>21</x>
-        <y>150</y>
+        <x>23</x>
+        <y>161</y>
         <width>65</width>
         <height>16</height>
        </rect>
@@ -108,8 +78,8 @@
       <property name="geometry">
        <rect>
         <x>100</x>
-        <y>139</y>
-        <width>133</width>
+        <y>150</y>
+        <width>111</width>
         <height>31</height>
        </rect>
       </property>
@@ -123,10 +93,10 @@
      <widget class="QLabel" name="label_4">
       <property name="geometry">
        <rect>
-        <x>310</x>
-        <y>80</y>
+        <x>500</x>
+        <y>90</y>
         <width>71</width>
-        <height>16</height>
+        <height>20</height>
        </rect>
       </property>
       <property name="text">
@@ -136,8 +106,8 @@
      <widget class="QLineEdit" name="tipoEquipamento">
       <property name="geometry">
        <rect>
-        <x>389</x>
-        <y>69</y>
+        <x>580</x>
+        <y>80</y>
         <width>133</width>
         <height>31</height>
        </rect>
@@ -149,9 +119,9 @@
      <widget class="QComboBox" name="nomePredio">
       <property name="geometry">
        <rect>
-        <x>99</x>
-        <y>69</y>
-        <width>81</width>
+        <x>101</x>
+        <y>80</y>
+        <width>111</width>
         <height>31</height>
        </rect>
       </property>
@@ -181,8 +151,8 @@
      <widget class="QLabel" name="label_3">
       <property name="geometry">
        <rect>
-        <x>20</x>
-        <y>80</y>
+        <x>22</x>
+        <y>91</y>
         <width>41</width>
         <height>16</height>
        </rect>
@@ -194,9 +164,9 @@
      <widget class="QComboBox" name="tipoSala">
       <property name="geometry">
        <rect>
-        <x>400</x>
-        <y>9</y>
-        <width>81</width>
+        <x>580</x>
+        <y>20</y>
+        <width>91</width>
         <height>31</height>
        </rect>
       </property>
@@ -239,9 +209,9 @@
      <widget class="QLabel" name="label_2">
       <property name="geometry">
        <rect>
-        <x>310</x>
-        <y>20</y>
-        <width>65</width>
+        <x>500</x>
+        <y>28</y>
+        <width>71</width>
         <height>16</height>
        </rect>
       </property>
@@ -252,8 +222,8 @@
      <widget class="QLabel" name="label_7">
       <property name="geometry">
        <rect>
-        <x>20</x>
-        <y>20</y>
+        <x>22</x>
+        <y>31</y>
         <width>65</width>
         <height>16</height>
        </rect>
@@ -265,9 +235,9 @@
      <widget class="QComboBox" name="nomeSala">
       <property name="geometry">
        <rect>
-        <x>100</x>
-        <y>10</y>
-        <width>81</width>
+        <x>102</x>
+        <y>21</y>
+        <width>111</width>
         <height>31</height>
        </rect>
       </property>
@@ -287,6 +257,35 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Observações</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="feedbackText">
+     <property name="minimumSize">
+      <size>
+       <width>125</width>
+       <height>125</height>
+      </size>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="placeholderText">
+      <string>Observações adicionais</string>
+     </property>
+     <property name="cursorMoveStyle">
+      <enum>Qt::VisualMoveStyle</enum>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QPushButton" name="btnEditarSala">
      <property name="minimumSize">
       <size>
@@ -294,8 +293,13 @@
        <height>41</height>
       </size>
      </property>
+     <property name="font">
+      <font>
+       <pointsize>17</pointsize>
+      </font>
+     </property>
      <property name="text">
-      <string>EDITAR SALA</string>
+      <string>Editar sala</string>
      </property>
     </widget>
    </item>

--- a/App/view/ui/home.ui
+++ b/App/view/ui/home.ui
@@ -43,7 +43,7 @@
 
 #btnFecharPagina:hover {
 	background-color: #E81123;
-	color: #FFF;
+	color: #fff;
 	icon: url(&quot;App/view/ui/icones/iconCloseBranco.png&quot;);
 }
 

--- a/App/view/ui/reserva.ui
+++ b/App/view/ui/reserva.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>865</width>
-    <height>655</height>
+    <width>1124</width>
+    <height>888</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,14 +37,62 @@
 #observacaoReserva {
 	background-color: white;
 }
+
+#segunda {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
+
+#terca {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
+
+#quarta {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
+
+#quinta {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
+
+#sexta {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
+
+#sabado {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 10px; 
+}
  
 #respostas {
 	color: red;
 }</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>RESERVA  DE SALA</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QFrame" name="ReservaDeSala">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
      </property>
@@ -54,8 +102,8 @@
      <widget class="QLabel" name="label_4">
       <property name="geometry">
        <rect>
-        <x>560</x>
-        <y>60</y>
+        <x>740</x>
+        <y>50</y>
         <width>91</width>
         <height>16</height>
        </rect>
@@ -80,7 +128,7 @@
      <widget class="QLabel" name="label_6">
       <property name="geometry">
        <rect>
-        <x>320</x>
+        <x>430</x>
         <y>130</y>
         <width>61</width>
         <height>16</height>
@@ -90,38 +138,11 @@
        <string>PERIODO:</string>
       </property>
      </widget>
-     <widget class="QPushButton" name="btnFazerReserva">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>570</y>
-        <width>801</width>
-        <height>47</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>762</width>
-        <height>47</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <pointsize>17</pointsize>
-       </font>
-      </property>
-      <property name="cursor">
-       <cursorShape>PointingHandCursor</cursorShape>
-      </property>
-      <property name="text">
-       <string>RESERVA</string>
-      </property>
-     </widget>
      <widget class="QLabel" name="label_13">
       <property name="geometry">
        <rect>
         <x>30</x>
-        <y>60</y>
+        <y>50</y>
         <width>161</width>
         <height>16</height>
        </rect>
@@ -133,8 +154,8 @@
      <widget class="QLabel" name="label_3">
       <property name="geometry">
        <rect>
-        <x>320</x>
-        <y>60</y>
+        <x>430</x>
+        <y>50</y>
         <width>31</width>
         <height>16</height>
        </rect>
@@ -143,81 +164,27 @@
        <string>SALA:</string>
       </property>
      </widget>
-     <widget class="QLabel" name="label">
-      <property name="geometry">
-       <rect>
-        <x>310</x>
-        <y>10</y>
-        <width>151</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="font">
-       <font>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="text">
-       <string>RESERVA  DE SALA</string>
-      </property>
-     </widget>
-     <widget class="QLineEdit" name="observacaoReserva">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>450</y>
-        <width>781</width>
-        <height>101</height>
-       </rect>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignCenter</set>
-      </property>
-      <property name="placeholderText">
-       <string>OBSERVAÇÕES A SEREM ACRESCENTADAS</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label_7">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>410</y>
-        <width>81</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>OBSERVAÇÕES:</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="feedbackReserva">
-      <property name="geometry">
-       <rect>
-        <x>210</x>
-        <y>430</y>
-        <width>161</width>
-        <height>31</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
      <widget class="QLineEdit" name="equipamentosReserva">
       <property name="geometry">
        <rect>
-        <x>560</x>
+        <x>740</x>
         <y>82</y>
-        <width>113</width>
+        <width>211</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>10</height>
+       </size>
       </property>
      </widget>
      <widget class="QLabel" name="label_5">
       <property name="geometry">
        <rect>
-        <x>31</x>
-        <y>216</y>
+        <x>260</x>
+        <y>228</y>
         <width>131</width>
         <height>20</height>
        </rect>
@@ -229,8 +196,8 @@
      <widget class="QLabel" name="label_8">
       <property name="geometry">
        <rect>
-        <x>31</x>
-        <y>266</y>
+        <x>260</x>
+        <y>299</y>
         <width>131</width>
         <height>16</height>
        </rect>
@@ -242,11 +209,17 @@
      <widget class="QComboBox" name="salaReserva">
       <property name="geometry">
        <rect>
-        <x>320</x>
+        <x>430</x>
         <y>81</y>
-        <width>111</width>
+        <width>161</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>10</height>
+       </size>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
@@ -260,9 +233,15 @@
        <rect>
         <x>30</x>
         <y>151</y>
-        <width>161</width>
+        <width>261</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>10</height>
+       </size>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
@@ -275,10 +254,16 @@
       <property name="geometry">
        <rect>
         <x>30</x>
-        <y>81</y>
-        <width>161</width>
+        <y>80</y>
+        <width>261</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>10</height>
+       </size>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
@@ -290,21 +275,33 @@
      <widget class="QDateEdit" name="diaInicio">
       <property name="geometry">
        <rect>
-        <x>171</x>
-        <y>207</y>
+        <x>400</x>
+        <y>219</y>
         <width>81</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>10</height>
+       </size>
       </property>
      </widget>
      <widget class="QDateEdit" name="diaFim">
       <property name="geometry">
        <rect>
-        <x>171</x>
-        <y>257</y>
+        <x>400</x>
+        <y>290</y>
         <width>81</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>10</height>
+       </size>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
@@ -313,11 +310,17 @@
      <widget class="QComboBox" name="periodoReserva">
       <property name="geometry">
        <rect>
-        <x>320</x>
+        <x>430</x>
         <y>151</y>
         <width>111</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>10</height>
+       </size>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
@@ -344,8 +347,8 @@
      <widget class="QLabel" name="label_9">
       <property name="geometry">
        <rect>
-        <x>160</x>
-        <y>313</y>
+        <x>40</x>
+        <y>339</y>
         <width>91</width>
         <height>16</height>
        </rect>
@@ -357,8 +360,8 @@
      <widget class="QLabel" name="label_10">
       <property name="geometry">
        <rect>
-        <x>291</x>
-        <y>216</y>
+        <x>580</x>
+        <y>229</y>
         <width>101</width>
         <height>16</height>
        </rect>
@@ -370,8 +373,8 @@
      <widget class="QLabel" name="label_11">
       <property name="geometry">
        <rect>
-        <x>291</x>
-        <y>266</y>
+        <x>580</x>
+        <y>299</y>
         <width>91</width>
         <height>16</height>
        </rect>
@@ -383,11 +386,17 @@
      <widget class="QTimeEdit" name="fimCurso">
       <property name="geometry">
        <rect>
-        <x>401</x>
-        <y>257</y>
+        <x>690</x>
+        <y>290</y>
         <width>118</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>10</height>
+       </size>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
@@ -396,11 +405,17 @@
      <widget class="QTimeEdit" name="inicioCurso">
       <property name="geometry">
        <rect>
-        <x>401</x>
-        <y>207</y>
+        <x>690</x>
+        <y>220</y>
         <width>118</width>
         <height>31</height>
        </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>10</height>
+       </size>
       </property>
       <property name="cursor">
        <cursorShape>PointingHandCursor</cursorShape>
@@ -409,15 +424,15 @@
      <widget class="QWidget" name="widget" native="true">
       <property name="geometry">
        <rect>
-        <x>160</x>
-        <y>335</y>
-        <width>451</width>
-        <height>71</height>
+        <x>40</x>
+        <y>359</y>
+        <width>931</width>
+        <height>111</height>
        </rect>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="QWidget" name="widget_9" native="true">
+        <widget class="QWidget" name="segunda" native="true">
          <widget class="QWidget" name="layoutWidget_2">
           <property name="geometry">
            <rect>
@@ -450,7 +465,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget_4" native="true">
+        <widget class="QWidget" name="terca" native="true">
          <widget class="QWidget" name="layoutWidget">
           <property name="geometry">
            <rect>
@@ -483,7 +498,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget_5" native="true">
+        <widget class="QWidget" name="quarta" native="true">
          <widget class="QWidget" name="layoutWidget">
           <property name="geometry">
            <rect>
@@ -516,7 +531,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget_3" native="true">
+        <widget class="QWidget" name="quinta" native="true">
          <widget class="QWidget" name="layoutWidget">
           <property name="geometry">
            <rect>
@@ -549,7 +564,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget_6" native="true">
+        <widget class="QWidget" name="sexta" native="true">
          <widget class="QWidget" name="layoutWidget">
           <property name="geometry">
            <rect>
@@ -585,7 +600,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget_7" native="true">
+        <widget class="QWidget" name="sabado" native="true">
          <property name="tabletTracking">
           <bool>false</bool>
          </property>
@@ -622,6 +637,56 @@
        </item>
       </layout>
      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>OBSERVAÇÕES:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="observacaoReserva">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>721</width>
+       <height>125</height>
+      </size>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="placeholderText">
+      <string>OBSERVAÇÕES A SEREM ACRESCENTADAS</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnFazerReserva">
+     <property name="minimumSize">
+      <size>
+       <width>762</width>
+       <height>47</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>17</pointsize>
+      </font>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="text">
+      <string>Reserva</string>
+     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Telas de `cadastros` e `editar` modificadas para ficaem de acordo com a tela.

**Exemplo da tela de reserva:**

![image](https://github.com/user-attachments/assets/a1073190-544f-49bd-b41b-eada41430d83)
 