### PR TITLE
Tela de editar curso alterado

### DIFF
--- a/App/view/ui/editarCurso.ui
+++ b/App/view/ui/editarCurso.ui
@@ -231,6 +231,9 @@
         <height>31</height>
        </rect>
       </property>
+      <property name="cursor">
+       <cursorShape>PointingHandCursor</cursorShape>
+      </property>
      </widget>
      <widget class="QSpinBox" name="quantidadeAlunos">
       <property name="geometry">

--- a/App/view/ui/editarCurso.ui
+++ b/App/view/ui/editarCurso.ui
@@ -14,7 +14,7 @@
    <string>Form</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">QLineEdit, QComboBox {
+   <string notr="true">QLineEdit, QComboBox, QSpinBox {
 	background-color: white;
 	border:2px solid rgba(0,0,0,0);
 	border-radius: 4px;
@@ -40,7 +40,9 @@
  
 #respostaCadastroIncompleto {
 	color: red;
-}</string>
+}
+
+</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item alignment="Qt::AlignHCenter|Qt::AlignTop">
@@ -72,9 +74,9 @@
      <widget class="QLineEdit" name="nomeCurso">
       <property name="geometry">
        <rect>
-        <x>70</x>
+        <x>340</x>
         <y>129</y>
-        <width>131</width>
+        <width>141</width>
         <height>31</height>
        </rect>
       </property>
@@ -85,7 +87,7 @@
      <widget class="QLabel" name="label_2">
       <property name="geometry">
        <rect>
-        <x>70</x>
+        <x>340</x>
         <y>106</y>
         <width>81</width>
         <height>20</height>
@@ -95,51 +97,12 @@
        <string>Nome do Curso</string>
       </property>
      </widget>
-     <widget class="QLineEdit" name="quantidadeAlunos">
-      <property name="geometry">
-       <rect>
-        <x>340</x>
-        <y>360</y>
-        <width>141</width>
-        <height>31</height>
-       </rect>
-      </property>
-      <property name="placeholderText">
-       <string>Quantidade de Alunos </string>
-      </property>
-     </widget>
-     <widget class="QLineEdit" name="ofertaCurso">
-      <property name="geometry">
-       <rect>
-        <x>340</x>
-        <y>129</y>
-        <width>141</width>
-        <height>31</height>
-       </rect>
-      </property>
-      <property name="placeholderText">
-       <string>Oferta do Curso</string>
-      </property>
-     </widget>
-     <widget class="QLineEdit" name="horasPorDia">
-      <property name="geometry">
-       <rect>
-        <x>70</x>
-        <y>359</y>
-        <width>131</width>
-        <height>31</height>
-       </rect>
-      </property>
-      <property name="placeholderText">
-       <string>Horário do Curso</string>
-      </property>
-     </widget>
      <widget class="QLabel" name="label_3">
       <property name="geometry">
        <rect>
         <x>340</x>
         <y>215</y>
-        <width>71</width>
+        <width>81</width>
         <height>21</height>
        </rect>
       </property>
@@ -150,14 +113,14 @@
      <widget class="QLabel" name="label_4">
       <property name="geometry">
        <rect>
-        <x>340</x>
-        <y>103</y>
-        <width>47</width>
+        <x>70</x>
+        <y>104</y>
+        <width>81</width>
         <height>20</height>
        </rect>
       </property>
       <property name="text">
-       <string>Oferta</string>
+       <string>Oferta do Curso</string>
       </property>
      </widget>
      <widget class="QLabel" name="label_5">
@@ -197,19 +160,6 @@
       </property>
       <property name="text">
        <string>Período do Curso</string>
-      </property>
-     </widget>
-     <widget class="QLineEdit" name="cargaCurso">
-      <property name="geometry">
-       <rect>
-        <x>340</x>
-        <y>239</y>
-        <width>141</width>
-        <height>31</height>
-       </rect>
-      </property>
-      <property name="placeholderText">
-       <string>Carga Horária do Curso</string>
       </property>
      </widget>
      <widget class="QComboBox" name="periodoCurso">
@@ -272,30 +222,62 @@
        <string>Área</string>
       </property>
      </widget>
-     <widget class="QComboBox" name="alterarCurso">
+     <widget class="QComboBox" name="ofertaCurso">
       <property name="geometry">
        <rect>
-        <x>600</x>
-        <y>241</y>
-        <width>121</width>
+        <x>70</x>
+        <y>130</y>
+        <width>141</width>
         <height>31</height>
        </rect>
       </property>
-      <property name="cursor">
-       <cursorShape>PointingHandCursor</cursorShape>
-      </property>
      </widget>
-     <widget class="QLabel" name="label_9">
+     <widget class="QSpinBox" name="quantidadeAlunos">
       <property name="geometry">
        <rect>
-        <x>600</x>
-        <y>220</y>
-        <width>71</width>
-        <height>16</height>
+        <x>340</x>
+        <y>360</y>
+        <width>141</width>
+        <height>31</height>
        </rect>
       </property>
-      <property name="text">
-       <string>Alterar Curso</string>
+      <property name="alignment">
+       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+      </property>
+      <property name="minimum">
+       <number>1</number>
+      </property>
+     </widget>
+     <widget class="QSpinBox" name="cargaCurso">
+      <property name="geometry">
+       <rect>
+        <x>340</x>
+        <y>250</y>
+        <width>141</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+      </property>
+      <property name="minimum">
+       <number>1</number>
+      </property>
+     </widget>
+     <widget class="QSpinBox" name="horasPorDia">
+      <property name="geometry">
+       <rect>
+        <x>70</x>
+        <y>360</y>
+        <width>141</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+      </property>
+      <property name="minimum">
+       <number>1</number>
       </property>
      </widget>
     </widget>


### PR DESCRIPTION
removido campo de `alterarCurso` e adicionado `SpinBox` para aceitar somente números ao invés de textos

**Tela de editar curso**
![image](https://github.com/user-attachments/assets/5ffc3cb4-f5d9-4246-8e4f-ee7c0fc39820)
