### PR TITLE
Limpando campos Tela Login

### DIFF
--- a/App/view/login.py
+++ b/App/view/login.py
@@ -100,6 +100,13 @@ class LoginInterface(QDialog):
         campos = self.getEmailSenha()
         if validarLogin(campos[0], campos[1]):
             self.accept()
+
+            # Limpando campos
+            self.limparCampos(self.inputEmail)
+            self.limparCampos(self.inputSenha)
+
+            # Focus no campo de email
+            self.inputEmail.setFocus()
         else:
             self.dadosInvalidos()
  


### PR DESCRIPTION
No login, ao clicar no botão para entrar, os campos são limpos, e o foco é setado para o input de email.
Dessa forma quando for feito o logout, voltará para a página de login com os campos limpos.
#177 