### PR TITLE
Melhorias na reserva

### DIFF
--- a/App/view/ui/reserva.ui
+++ b/App/view/ui/reserva.ui
@@ -70,6 +70,10 @@
  
 #respostas {
   color: red;
+}
+
+#titulo {
+color: #f6921e
 }</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -156,6 +160,11 @@
               <layout class="QVBoxLayout" name="verticalLayout_2">
                <item>
                 <widget class="QLabel" name="label_13">
+                 <property name="font">
+                  <font>
+                   <pointsize>12</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>NOME DOCENTES/RESPONSAVEL:</string>
                  </property>
@@ -175,11 +184,13 @@
                    <height>47</height>
                   </size>
                  </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>12</pointsize>
+                  </font>
+                 </property>
                  <property name="cursor">
                   <cursorShape>PointingHandCursor</cursorShape>
-                 </property>
-                 <property name="editable">
-                  <bool>true</bool>
                  </property>
                 </widget>
                </item>
@@ -196,22 +207,38 @@
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_5">
                <item>
-                <widget class="QLabel" name="label_4">
-                 <property name="text">
-                  <string>EQUIPAMENTOS:</string>
+                <widget class="QLabel" name="label_2">
+                 <property name="font">
+                  <font>
+                   <pointsize>12</pointsize>
+                  </font>
                  </property>
-                 <property name="alignment">
-                  <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+                 <property name="text">
+                  <string>CURSO:</string>
                  </property>
                 </widget>
                </item>
                <item>
-                <widget class="QLineEdit" name="equipamentosReserva">
+                <widget class="QComboBox" name="cursoReserva">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
                  <property name="minimumSize">
                   <size>
-                   <width>0</width>
+                   <width>130</width>
                    <height>47</height>
                   </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>12</pointsize>
+                  </font>
+                 </property>
+                 <property name="cursor">
+                  <cursorShape>PointingHandCursor</cursorShape>
                  </property>
                 </widget>
                </item>
@@ -253,6 +280,11 @@
               <layout class="QVBoxLayout" name="verticalLayout_4">
                <item>
                 <widget class="QLabel" name="label_3">
+                 <property name="font">
+                  <font>
+                   <pointsize>12</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>SALA:</string>
                  </property>
@@ -271,6 +303,11 @@
                    <width>0</width>
                    <height>47</height>
                   </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>12</pointsize>
+                  </font>
                  </property>
                  <property name="cursor">
                   <cursorShape>PointingHandCursor</cursorShape>
@@ -291,6 +328,11 @@
               <layout class="QVBoxLayout" name="verticalLayout_3">
                <item>
                 <widget class="QLabel" name="label_6">
+                 <property name="font">
+                  <font>
+                   <pointsize>12</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>NOME DO CURSO:</string>
                  </property>
@@ -306,6 +348,11 @@
                    <width>0</width>
                    <height>47</height>
                   </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>12</pointsize>
+                  </font>
                  </property>
                  <property name="cursor">
                   <cursorShape>PointingHandCursor</cursorShape>
@@ -343,28 +390,35 @@
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
                <item>
-                <widget class="QLabel" name="label_2">
+                <widget class="QLabel" name="label_4">
+                 <property name="font">
+                  <font>
+                   <pointsize>12</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
-                  <string>CURSO:</string>
+                  <string>EQUIPAMENTOS:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
                  </property>
                 </widget>
                </item>
                <item>
-                <widget class="QComboBox" name="cursoReserva">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
+                <widget class="QLineEdit" name="equipamentosReserva">
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
                    <height>47</height>
                   </size>
                  </property>
-                 <property name="cursor">
-                  <cursorShape>PointingHandCursor</cursorShape>
+                 <property name="font">
+                  <font>
+                   <pointsize>12</pointsize>
+                  </font>
+                 </property>
+                 <property name="mouseTracking">
+                  <bool>true</bool>
                  </property>
                 </widget>
                </item>
@@ -438,6 +492,11 @@
               <layout class="QVBoxLayout" name="verticalLayout_19">
                <item>
                 <widget class="QLabel" name="label_5">
+                 <property name="font">
+                  <font>
+                   <pointsize>11</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>DATA INÍCIAL DO CURSO:</string>
                  </property>
@@ -453,9 +512,14 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>0</width>
-                   <height>35</height>
+                   <width>117</width>
+                   <height>39</height>
                   </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>11</pointsize>
+                  </font>
                  </property>
                  <property name="cursor">
                   <cursorShape>PointingHandCursor</cursorShape>
@@ -476,6 +540,11 @@
               <layout class="QVBoxLayout" name="verticalLayout_20">
                <item>
                 <widget class="QLabel" name="label_8">
+                 <property name="font">
+                  <font>
+                   <pointsize>11</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>DATA FINAL DO CURSO:</string>
                  </property>
@@ -491,9 +560,14 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>0</width>
-                   <height>35</height>
+                   <width>117</width>
+                   <height>39</height>
                   </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>11</pointsize>
+                  </font>
                  </property>
                  <property name="cursor">
                   <cursorShape>PointingHandCursor</cursorShape>
@@ -526,6 +600,11 @@
               <layout class="QVBoxLayout" name="verticalLayout_22">
                <item>
                 <widget class="QLabel" name="label_10">
+                 <property name="font">
+                  <font>
+                   <pointsize>11</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>HORA DE INÍCIO:</string>
                  </property>
@@ -541,9 +620,14 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>0</width>
+                   <width>80</width>
                    <height>35</height>
                   </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>11</pointsize>
+                  </font>
                  </property>
                  <property name="cursor">
                   <cursorShape>PointingHandCursor</cursorShape>
@@ -564,6 +648,11 @@
               <layout class="QVBoxLayout" name="verticalLayout_21">
                <item>
                 <widget class="QLabel" name="label_11">
+                 <property name="font">
+                  <font>
+                   <pointsize>11</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>HORA FIM:</string>
                  </property>
@@ -579,9 +668,14 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>0</width>
+                   <width>80</width>
                    <height>35</height>
                   </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>11</pointsize>
+                  </font>
                  </property>
                  <property name="cursor">
                   <cursorShape>PointingHandCursor</cursorShape>
@@ -666,7 +760,7 @@
              <widget class="QLabel" name="label_18">
               <property name="font">
                <font>
-                <pointsize>10</pointsize>
+                <pointsize>13</pointsize>
                </font>
               </property>
               <property name="text">
@@ -709,7 +803,7 @@
              <widget class="QLabel" name="label_12">
               <property name="font">
                <font>
-                <pointsize>10</pointsize>
+                <pointsize>13</pointsize>
                </font>
               </property>
               <property name="text">
@@ -757,7 +851,7 @@
              <widget class="QLabel" name="label_14">
               <property name="font">
                <font>
-                <pointsize>10</pointsize>
+                <pointsize>13</pointsize>
                </font>
               </property>
               <property name="text">
@@ -800,7 +894,7 @@
              <widget class="QLabel" name="label_15">
               <property name="font">
                <font>
-                <pointsize>10</pointsize>
+                <pointsize>13</pointsize>
                </font>
               </property>
               <property name="text">
@@ -848,7 +942,7 @@
              <widget class="QLabel" name="label_16">
               <property name="font">
                <font>
-                <pointsize>10</pointsize>
+                <pointsize>13</pointsize>
                </font>
               </property>
               <property name="text">
@@ -894,7 +988,7 @@
              <widget class="QLabel" name="label_17">
               <property name="font">
                <font>
-                <pointsize>10</pointsize>
+                <pointsize>13</pointsize>
                </font>
               </property>
               <property name="text">
@@ -945,6 +1039,11 @@
    </item>
    <item>
     <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
      <property name="text">
       <string>OBSERVAÇÕES:</string>
      </property>
@@ -990,6 +1089,9 @@
        <pointsize>17</pointsize>
       </font>
      </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
      <property name="text">
       <string>RESERVAR</string>
      </property>
@@ -997,6 +1099,24 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>salaReserva</tabstop>
+  <tabstop>equipamentosReserva</tabstop>
+  <tabstop>cursoReserva</tabstop>
+  <tabstop>nomeCurso</tabstop>
+  <tabstop>diaInicio</tabstop>
+  <tabstop>inicioCurso</tabstop>
+  <tabstop>diaFim</tabstop>
+  <tabstop>fimCurso</tabstop>
+  <tabstop>segCheck</tabstop>
+  <tabstop>terCheck</tabstop>
+  <tabstop>quaCheck</tabstop>
+  <tabstop>quiCheck</tabstop>
+  <tabstop>sextaCheck</tabstop>
+  <tabstop>sabCheck</tabstop>
+  <tabstop>observacaoReserva</tabstop>
+  <tabstop>btnFazerReserva</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Adicionado novo layout para a tela de `reservas de sala`, arrumado a `tabulação`, e adicionado cor no **titulo** para estar de acordo com as outras telas

![image](https://github.com/user-attachments/assets/746f1910-2767-4689-946b-e542ecdf101a)
