### PR TITLE
Tela conflitos

### DIFF
--- a/App/view/feedback.py
+++ b/App/view/feedback.py
@@ -12,7 +12,8 @@ from winotify import Notification, audio
 class Feedback(QDialog):
     CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
-    def __init__(self, type, txt, aviso, typemsg):
+
+    def __init__(self, tipo:bool, txt:str, aviso:str, typemsg:str):
         super().__init__()
         loadUi('App/view/ui/feedback.ui', self)
         # Variáveis para armazenar o estado da movimentação
@@ -23,52 +24,30 @@ class Feedback(QDialog):
         
         self.btnFechar2.clicked.connect(self.reject)
         self.btnFechar.clicked.connect(self.accept)
-        
         self.texto.setText(txt)
-        
-
         self.player = QtMultimedia.QMediaPlayer()
-
+        self.notificacao(aviso, typemsg)
+        self.tocarAudio(tipo)
         
-        #notificação de erro
-        if type == False:
+        # notificação de sucesso
+        icon_path = os.path.join(self.CURRENT_DIR, r"./ui/icones/iconConcluido.png")
+        if tipo == False:
             icon_path = os.path.join(self.CURRENT_DIR, r"./ui/icones/iconErro.png")
-            self.icon.setPixmap(QPixmap(icon_path))
-            # toca alertinha de erro
-            filename = os.path.join(self.CURRENT_DIR, "./ui/sounds/erroToque.mp3")
-            url = QtCore.QUrl.fromLocalFile(filename)
-            self.player.setMedia(QtMultimedia.QMediaContent(url))
-            self.player.play()
-            
-            #mostra uma notificação no windows para o usuario sobre o erro
-            filenameNotificacao = os.path.join(self.CURRENT_DIR, r"ui\icones\iconNotificacao.png")
-            notificacao = Notification( app_id='Mapa de Sala',
-                                       title=aviso,
-                                       msg=typemsg, 
-                                       icon=filenameNotificacao )
-            # notificacao.set_audio(audio.LoopingCall2, loop=False)
-            notificacao.add_actions(label='Fechar')
-            notificacao.show()
-            
-        #notificação de sucesso
-        if type == True:
-            icon_path = os.path.join(self.CURRENT_DIR, r"./ui/icones/iconConcluido.png")
-            self.icon.setPixmap(QPixmap(icon_path))
-            # toca alertinha de erro
-            filename = os.path.join(self.CURRENT_DIR, "./ui/sounds/sucessoNotificacao.mp3")
-            url = QtCore.QUrl.fromLocalFile(filename)
-            self.player.setMedia(QtMultimedia.QMediaContent(url))
-            self.player.play()
-            
-            #mostra uma notificação no windows para o usuario sobre o erro
-            filenameNotificacao = os.path.join(self.CURRENT_DIR, r"ui\icones\iconNotificacao.png")
-            notificacao = Notification( app_id='Mapa de Sala',
-                                       title=aviso,
-                                       msg=typemsg,
-                                       icon=filenameNotificacao )
-            # notificacao.set_audio(audio.LoopingCall2, loop=False)
-            notificacao.add_actions(label='Fechar')
-            notificacao.show()
+        self.icon.setPixmap(QPixmap(icon_path))
+        
+
+
+    def notificacao(self, aviso, typemsg):
+        filenameNotificacao = os.path.join(self.CURRENT_DIR, r"ui\icones\iconNotificacao.png")
+        notificacao = Notification(app_id='Mapa de Sala', title=aviso, msg=typemsg, icon=filenameNotificacao)
+        notificacao.add_actions(label='Fechar')
+        notificacao.show()
+
+    def tocarAudio(self, sucesso=True):
+        som = 'sucessoNotificacao' if sucesso else 'erroToque'
+        url = QtCore.QUrl.fromLocalFile(os.path.join(self.CURRENT_DIR, f"./ui/sounds/{som}.mp3"))
+        self.player.setMedia(QtMultimedia.QMediaContent(url))
+        self.player.play()
 
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:

--- a/App/view/home.py
+++ b/App/view/home.py
@@ -216,7 +216,7 @@ class HomePrincipal(QMainWindow):
         self.subMenuQuebrado.hide()
 
     def fazer_logout(self):
-        confirmacao = TelaConfirmacao("Tem certeza que deseja sair?", '', "Sim", False, False)
+        confirmacao = TelaConfirmacao("Tem certeza que deseja sair?", '', "Sim")
         if confirmacao.exec_():
             removerUsuarioLogado()
             self.close()

--- a/App/view/home.py
+++ b/App/view/home.py
@@ -216,7 +216,7 @@ class HomePrincipal(QMainWindow):
         self.subMenuQuebrado.hide()
 
     def fazer_logout(self):
-        confirmacao = TelaConfirmacao("Tem certeza que deseja sair?", '', "Sim", False)
+        confirmacao = TelaConfirmacao("Tem certeza que deseja sair?", '', "Sim", False, False)
         if confirmacao.exec_():
             removerUsuarioLogado()
             self.close()

--- a/App/view/reserva.py
+++ b/App/view/reserva.py
@@ -121,7 +121,7 @@ class ReservaInterface(QWidget):
                 for dia, reserva in dias_ocupados.items():
                     txt += f'{dia} | {reserva[1][2]} - {reserva[1][3]}\n'
                     
-                confirmacao = TelaConfirmacao( 'Conflitos', txt, 'Confirmar')
+                confirmacao = TelaConfirmacao( 'Conflitos', True, 'Confirmar')
                 if confirmacao.exec_():
                     realizar_reserva_no_dia(idLogin.get('id_login'), info, dias_livres)
                     print('Reserva feita com sucesso!')

--- a/App/view/reserva.py
+++ b/App/view/reserva.py
@@ -121,7 +121,7 @@ class ReservaInterface(QWidget):
                 for dia, reserva in dias_ocupados.items():
                     txt += f'{dia} | {reserva[1][2]} - {reserva[1][3]}\n'
                     
-                confirmacao = TelaConfirmacao( 'Conflitos', True, 'Confirmar')
+                confirmacao = TelaConfirmacao( 'Conflitos', '', 'Confirmar', True, True)
                 if confirmacao.exec_():
                     realizar_reserva_no_dia(idLogin.get('id_login'), info, dias_livres)
                     print('Reserva feita com sucesso!')

--- a/App/view/telaConfirmacao.py
+++ b/App/view/telaConfirmacao.py
@@ -1,10 +1,11 @@
 from PyQt5.QtWidgets import QDialog
 from PyQt5.uic import loadUi
 from PyQt5.QtCore import Qt
+from .telaConflitos import TelaConflitos
 
 
 class TelaConfirmacao(QDialog):
-    def __init__(self, titulo, aviso, txtBtnOk, equipamentos=False):
+    def __init__(self, titulo, aviso, txtBtnOk, btnConflitos=False, equipamentos=False):
         super().__init__()
         loadUi('App/view/ui/telaConfirmacao.ui', self)
         
@@ -21,14 +22,22 @@ class TelaConfirmacao(QDialog):
             }
         """)
         
+        if btnConflitos == False:
+            self.btnAbrirConflitos.hide()
+        else: 
+            self.btnAbrirConflitos.show()
+        
         if aviso == '':
             self.aviso.close()
         else:
             self.aviso.setText(aviso)
+            
+            
         self.titulo.setText(titulo)
         self.btnOk.clicked.connect(self.accept)
         self.btnCancelar.clicked.connect(self.reject)
         self.btnFechar.clicked.connect(self.reject)
+        self.btnAbrirConflitos.clicked.connect(self.chamarTelaConflitos)
         
         # Remove a barra de título e as bordas da janela
         self.setWindowFlags(Qt.FramelessWindowHint)
@@ -41,6 +50,12 @@ class TelaConfirmacao(QDialog):
             self.containerEquipamentos.show()
         else:
             self.containerEquipamentos.hide()
+            
+            
+    def chamarTelaConflitos(self):
+        conflitos = TelaConflitos('')
+        if conflitos.exec_():
+            pass
         
 if __name__ == "__main__":
     from PyQt5.QtWidgets import QApplication

--- a/App/view/telaConflitos.py
+++ b/App/view/telaConflitos.py
@@ -1,0 +1,7 @@
+from PyQt5.QtWidgets import QDialog
+from PyQt5.uic import loadUi
+
+class TelaConflitos(QDialog):
+    def __init__(self):
+        super().__init__()
+        loadUi('App/view/ui/telaConflitos.ui', self)

--- a/App/view/telaConflitos.py
+++ b/App/view/telaConflitos.py
@@ -1,7 +1,34 @@
 from PyQt5.QtWidgets import QDialog
+from PyQt5.QtCore import Qt
 from PyQt5.uic import loadUi
 
 class TelaConflitos(QDialog):
-    def __init__(self):
+    def __init__(self, textoConflitos):
         super().__init__()
         loadUi('App/view/ui/telaConflitos.ui', self)
+        
+        self.setWindowFlags(Qt.FramelessWindowHint)
+        
+        # self.setAttribute(Qt.WA_TranslucentBackground)
+        
+        self.textoConflitos.setText(textoConflitos)
+        
+        self.btnTelaCheia.clicked.connect(self.windowConnect)
+        self.btnFechar.clicked.connect(self.close)
+ 
+    def windowConnect(self):
+        if self.isMaximized():
+            self.showNormal()
+            self.btnTelaCheia.setStyleSheet("""
+                                           #btnTelaCheia {
+                                               icon: url("App/view/ui/icones/iconTelaCheia.png");
+                                            }"""
+                                        )
+           
+        else:
+            self.showMaximized()
+            self.btnTelaCheia.setStyleSheet("""
+                                        #btnTelaCheia {
+                                            icon: url("App/view/ui/icones/iconMinimezar.png");
+                                            }"""
+                                        )

--- a/App/view/ui/telaConfirmacao.ui
+++ b/App/view/ui/telaConfirmacao.ui
@@ -37,7 +37,14 @@ border-radius: 15px;
 color: #ffffff;
 }
 
-#btnOk:hover {
+#btnAbrirConflitos {
+	background-color: #01498a;
+border: none;
+border-radius: 10px;
+color: #ffffff;
+}
+
+#btnOk:hover, #btnAbrirConflitos:hover {
     background-color: #f6921e;
 }
 
@@ -166,6 +173,12 @@ color: #ffffff;
       </item>
       <item alignment="Qt::AlignHCenter">
        <widget class="QPushButton" name="btnAbrirConflitos">
+        <property name="minimumSize">
+         <size>
+          <width>121</width>
+          <height>29</height>
+         </size>
+        </property>
         <property name="font">
          <font>
           <pointsize>12</pointsize>

--- a/App/view/ui/telaConfirmacao.ui
+++ b/App/view/ui/telaConfirmacao.ui
@@ -164,6 +164,21 @@ color: #ffffff;
         </property>
        </widget>
       </item>
+      <item alignment="Qt::AlignHCenter">
+       <widget class="QPushButton" name="btnAbrirConflitos">
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
+        <property name="text">
+         <string>Ver Conflitos</string>
+        </property>
+       </widget>
+      </item>
       <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
        <widget class="QLabel" name="aviso">
         <property name="minimumSize">

--- a/App/view/ui/telaConflitos.ui
+++ b/App/view/ui/telaConflitos.ui
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>409</width>
+    <height>591</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item alignment="Qt::AlignRight">
+    <widget class="QPushButton" name="btnFechar">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset>
+       <normaloff>../../../../../../Users/richard.sleao/source/repos/interfaceS/App/view/ui/icones/iconClosePreto.png</normaloff>../../../../../../Users/richard.sleao/source/repos/interfaceS/App/view/ui/icones/iconClosePreto.png</iconset>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item alignment="Qt::AlignHCenter">
+       <widget class="QLabel" name="tituloConflitos">
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>Conflitos</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QScrollArea" name="scrollArea">
+        <property name="minimumSize">
+         <size>
+          <width>399</width>
+          <height>526</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>390</width>
+          <height>526</height>
+         </size>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustIgnored</enum>
+        </property>
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>397</width>
+           <height>524</height>
+          </rect>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QLabel" name="textoConflitos">
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/App/view/ui/telaConflitos.ui
+++ b/App/view/ui/telaConflitos.ui
@@ -6,59 +6,69 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>409</width>
-    <height>591</height>
+    <width>401</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">#principal {
+	border-radius: 15px;
+}
+
+#tituloConflitos {
+	color: #f6921e;
+}
+
+#btnFechar:hover {
+	background-color: #FF0000;
+	icon: url(&quot;App/view/ui/icones/iconCloseBranco.png&quot;);
+}
+
+#btnFechar,#btnTelaCheia {
+	border: none;
+	background-color: transparent;
+	border-radius: 12px;
+}
+
+#btnTelaCheia:hover {
+	background-color: #ccc;
+	color: #FFF;
+}
+</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
     <number>0</number>
    </property>
    <property name="leftMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>5</number>
+    <number>0</number>
    </property>
-   <item alignment="Qt::AlignRight">
-    <widget class="QPushButton" name="btnFechar">
-     <property name="font">
-      <font>
-       <pointsize>12</pointsize>
-      </font>
-     </property>
-     <property name="cursor">
-      <cursorShape>PointingHandCursor</cursorShape>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset>
-       <normaloff>../../../../../../Users/richard.sleao/source/repos/interfaceS/App/view/ui/icones/iconClosePreto.png</normaloff>../../../../../../Users/richard.sleao/source/repos/interfaceS/App/view/ui/icones/iconClosePreto.png</iconset>
-     </property>
-    </widget>
-   </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <property name="spacing">
-       <number>6</number>
-      </property>
+    <widget class="QFrame" name="principal">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
       <property name="leftMargin">
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>6</number>
+       <number>0</number>
       </property>
       <property name="rightMargin">
        <number>0</number>
@@ -66,16 +76,106 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item alignment="Qt::AlignHCenter">
-       <widget class="QLabel" name="tituloConflitos">
-        <property name="font">
-         <font>
-          <pointsize>12</pointsize>
-         </font>
+      <item alignment="Qt::AlignTop">
+       <widget class="QFrame" name="frame">
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
         </property>
-        <property name="text">
-         <string>Conflitos</string>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
         </property>
+        <layout class="QHBoxLayout" name="horizontalLayout" stretch="3,10,1,1">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item alignment="Qt::AlignHCenter">
+          <widget class="QLabel" name="tituloConflitos">
+           <property name="font">
+            <font>
+             <pointsize>17</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Conflitos</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnTelaCheia">
+           <property name="minimumSize">
+            <size>
+             <width>34</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>12</pointsize>
+            </font>
+           </property>
+           <property name="cursor">
+            <cursorShape>PointingHandCursor</cursorShape>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>icones/iconTelaCheia.png</normaloff>icones/iconTelaCheia.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnFechar">
+           <property name="minimumSize">
+            <size>
+             <width>34</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>12</pointsize>
+            </font>
+           </property>
+           <property name="cursor">
+            <cursorShape>PointingHandCursor</cursorShape>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>../../../../../../Users/richard.sleao/source/repos/interfaceS/App/view/ui/icones/iconClosePreto.png</normaloff>../../../../../../Users/richard.sleao/source/repos/interfaceS/App/view/ui/icones/iconClosePreto.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>
@@ -88,8 +188,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>390</width>
-          <height>526</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="sizeAdjustPolicy">
@@ -104,19 +204,25 @@
            <x>0</x>
            <y>0</y>
            <width>397</width>
-           <height>524</height>
+           <height>558</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
            <widget class="QLabel" name="textoConflitos">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="font">
              <font>
-              <pointsize>12</pointsize>
+              <pointsize>14</pointsize>
              </font>
             </property>
             <property name="text">
-             <string/>
+             <string>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</string>
             </property>
             <property name="scaledContents">
              <bool>true</bool>


### PR DESCRIPTION
adicionado a tela de conflitos que é puxada pela tela de confirmação, após chamar a tela de confirmação pode passar um parâmetro a mais, de verdadeiro ou falso, sendo: True ou False, assim o botão de chamar a tela de conflitos aparece

print tela de confirmação: 

![image](https://github.com/user-attachments/assets/8a98f6c8-90c9-4567-aff1-5e3d641c469c)

print da tela de conflitos:


![image](https://github.com/user-attachments/assets/46ef1040-e698-41d7-91dc-2cfd7f20c099)


print da tela de conflitos com texto de exemplo:


![image](https://github.com/user-attachments/assets/80a0a13b-2de8-4be8-9abb-cab5f52c042f)



